### PR TITLE
Python error handling

### DIFF
--- a/Lib/__init__.py
+++ b/Lib/__init__.py
@@ -1,8 +1,13 @@
 from cmor_const import *
 
-from pywrapper import axis,variable,write,setup,load_table,set_table,zfactor,close,grid,set_grid_mapping,time_varying_grid_coordinate,set_cur_dataset_attribute,get_cur_dataset_attribute,has_cur_dataset_attribute,create_output_path,set_variable_attribute,get_variable_attribute,has_variable_attribute,dataset_json,get_final_filename,set_deflate
+from pywrapper import (
+    CMORError, axis, variable, write, setup, load_table, set_table, zfactor,
+    close, grid, set_grid_mapping, time_varying_grid_coordinate, dataset_json,
+    set_cur_dataset_attribute, get_cur_dataset_attribute, create_output_path,
+    has_cur_dataset_attribute, set_variable_attribute, get_variable_attribute,
+    has_variable_attribute, get_final_filename, set_deflate)
 
 try:
-  from check_CMOR_compliant import checkCMOR
-except:
-  pass
+    from check_CMOR_compliant import checkCMOR
+except ImportError:
+    pass

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -1,11 +1,9 @@
+import numpy
+import os
 
-import cmor_const,numpy,os,_cmor
-import signal
-
-def sig_handler(signum, frame):
-    os.kill(os.getpid(),signal.SIGABRT)
-
-signal.signal(signal.SIGTERM, sig_handler)
+import cmor_const
+import _cmor
+from _cmor import CMORError
 
 try:
     import cdtime

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -4,11 +4,12 @@
 
 static PyObject *CMORError;
 volatile sig_atomic_t raise_exception = 0;
-char *message = "Problem with cmor.%s. Please check the logfile (if defined)";
+char *exception_message = "Problem with 'cmor.%s'. Please check the logfile "
+                          "(if defined).";
 int signal_to_catch = SIGTERM;
 
-void signal_handler(int sig) {
-    if (sig == signal_to_catch) {
+void signal_handler(int signal) {
+    if (signal == signal_to_catch) {
         raise_exception = 1;
     }
 }
@@ -40,7 +41,7 @@ static PyObject *PyCMOR_get_original_shape( PyObject * self,
     
     if (raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "get_original_shape");
+        PyErr_Format(CMORError, exception_message, "get_original_shape");
         return NULL;
     }
     
@@ -64,7 +65,7 @@ static PyObject *PyCMOR_set_cur_dataset_attribute(PyObject *self,
 
   if (ierr != 0 || raise_exception) {
     raise_exception = 0;
-    PyErr_Format(CMORError, message, "set_cur_dataset_attribute");
+    PyErr_Format(CMORError, exception_message, "set_cur_dataset_attribute");
     return NULL;
   }
   
@@ -88,7 +89,8 @@ static PyObject *PyCMOR_get_cur_dataset_attribute( PyObject * self,
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "get_cur_dataset_attribute");
+        PyErr_Format(CMORError, exception_message,
+                     "get_cur_dataset_attribute");
         return NULL;
     }
 
@@ -110,7 +112,8 @@ static PyObject *PyCMOR_has_cur_dataset_attribute( PyObject * self,
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "has_cur_dataset_attribute");
+        PyErr_Format(CMORError, exception_message,
+                     "has_cur_dataset_attribute");
         return NULL;
     }
     
@@ -132,7 +135,7 @@ static PyObject *PyCMOR_set_deflate( PyObject * self,
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "set_deflate");
+        PyErr_Format(CMORError, exception_message, "set_deflate");
         return NULL;
     }
     
@@ -157,7 +160,7 @@ static PyObject *PyCMOR_set_variable_attribute( PyObject * self,
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "set_variable_attribute");
+        PyErr_Format(CMORError, exception_message, "set_variable_attribute");
         return NULL;
     }
     
@@ -181,7 +184,7 @@ static PyObject *PyCMOR_get_variable_attribute( PyObject * self,
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "get_variable_attribute");
+        PyErr_Format(CMORError, exception_message, "get_variable_attribute");
         return NULL;
     }
 
@@ -204,7 +207,7 @@ static PyObject *PyCMOR_has_variable_attribute( PyObject * self,
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "has_variable_attribute");
+        PyErr_Format(CMORError, exception_message, "has_variable_attribute");
         return NULL;
     }
     
@@ -236,7 +239,7 @@ static PyObject *PyCMOR_setup( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "setup");
+        PyErr_Format(CMORError, exception_message, "setup");
         return NULL;
     }
     
@@ -350,7 +353,7 @@ static PyObject *PyCMOR_dataset_json( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "dataset_json");
+        PyErr_Format(CMORError, exception_message, "dataset_json");
         return NULL;
     }
     
@@ -373,7 +376,7 @@ static PyObject *PyCMOR_load_table( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "load_table");
+        PyErr_Format(CMORError, exception_message, "load_table");
         return NULL;
     }
 
@@ -476,7 +479,7 @@ static PyObject *PyCMOR_axis( PyObject * self, PyObject * args ) {
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "axis");
+        PyErr_Format(CMORError, exception_message, "axis");
         return NULL;
     }
 
@@ -498,7 +501,7 @@ static PyObject *PyCMOR_set_table( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "set_table");
+        PyErr_Format(CMORError, exception_message, "set_table");
         return NULL;
     }
     
@@ -572,7 +575,7 @@ static PyObject *PyCMOR_variable( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "variable");
+        PyErr_Format(CMORError, exception_message, "variable");
         return NULL;
     }
     
@@ -653,7 +656,7 @@ static PyObject *PyCMOR_zfactor( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "zfactor");
+        PyErr_Format(CMORError, exception_message, "zfactor");
         return NULL;
     }
     
@@ -705,7 +708,7 @@ static PyObject *PyCMOR_grid_mapping( PyObject * self, PyObject * args ) {
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "grid_mapping");
+        PyErr_Format(CMORError, exception_message, "grid_mapping");
         return NULL;
     }
     
@@ -795,7 +798,7 @@ static PyObject *PyCMOR_write( PyObject * self, PyObject * args ) {
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "write");
+        PyErr_Format(CMORError, exception_message, "write");
         return NULL;
     }
     
@@ -848,7 +851,7 @@ static PyObject *PyCMOR_close( PyObject * self, PyObject * args ) {
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "close");
+        PyErr_Format(CMORError, exception_message, "close");
         return NULL;
     } else {
 	if( dofile == 1 ) {
@@ -892,7 +895,8 @@ static PyObject *PyCMOR_time_varying_grid_coordinate( PyObject * self,
 
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "time_varying_grid_coordinate");
+        PyErr_Format(CMORError, exception_message,
+                     "time_varying_grid_coordinate");
         return NULL;
     }
     
@@ -987,7 +991,7 @@ static PyObject *PyCMOR_grid( PyObject * self, PyObject * args ) {
     
     if (ierr != 0 || raise_exception) {
         raise_exception = 0;
-        PyErr_Format(CMORError, message, "time_varying_grid_coordinate");
+        PyErr_Format(CMORError, exception_message, "grid");
         return NULL;
     }
     return Py_BuildValue( "i", id );
@@ -1030,6 +1034,6 @@ PyMODINIT_FUNC init_cmor( void ) {
     PyObject *cmor_module;
     cmor_module = Py_InitModule("_cmor", MyExtractMethods);
     import_array(  );
-    CMORError = PyErr_NewException("cmor.CMORError", NULL, NULL);
+    CMORError = PyErr_NewException("_cmor.CMORError", NULL, NULL);
     PyModule_AddObject(cmor_module, "CMORError", CMORError);
 }

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -1,12 +1,25 @@
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "cmor.h"
+
+static PyObject *CMORError;
+volatile sig_atomic_t raise_exception = 0;
+char *message = "Problem with cmor.%s. Please check the logfile (if defined)";
+int signal_to_catch = SIGTERM;
+
+void signal_handler(int sig) {
+    if (sig == signal_to_catch) {
+        raise_exception = 1;
+    }
+}
+
 /************************************************************************/
 /*                     PyCMOR_get_original_shape()                      */
 /************************************************************************/
 
 static PyObject *PyCMOR_get_original_shape( PyObject * self,
 					    PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int  i, shape_array[CMOR_MAX_DIMENSIONS], var_id, blank_time;
 
     i = CMOR_MAX_DIMENSIONS;
@@ -24,14 +37,22 @@ static PyObject *PyCMOR_get_original_shape( PyObject * self,
 	}
     }
     Py_INCREF( mylist );
+    
+    if (raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "get_original_shape");
+        return NULL;
+    }
+    
     return(mylist);
 }
+
 /************************************************************************/
 /*                  PyCMOR_set_cur_dataset_attribute()                  */
 /************************************************************************/
 static PyObject *PyCMOR_set_cur_dataset_attribute(PyObject *self,
-                                                  PyObject *args)
-{
+                                                  PyObject *args) {
+  signal(signal_to_catch, signal_handler);
   char *name;
   char *value;
   int ierr;
@@ -41,11 +62,13 @@ static PyObject *PyCMOR_set_cur_dataset_attribute(PyObject *self,
 
   ierr = cmor_set_cur_dataset_attribute(name, value, 1);
 
-  if (ierr != 0 ) return NULL;
-
-  Py_INCREF(Py_None);
-
-  return(Py_None);
+  if (ierr != 0 || raise_exception) {
+    raise_exception = 0;
+    PyErr_Format(CMORError, message, "set_cur_dataset_attribute");
+    return NULL;
+  }
+  
+  return Py_BuildValue( "i", ierr );
 }
 
 /************************************************************************/
@@ -53,16 +76,23 @@ static PyObject *PyCMOR_set_cur_dataset_attribute(PyObject *self,
 /************************************************************************/
 static PyObject *PyCMOR_get_cur_dataset_attribute( PyObject * self,
 						   PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     char *name;
     char value[CMOR_MAX_STRING];
     int ierr;
 
     if( !PyArg_ParseTuple( args, "s", &name ) )
 	return NULL;
+    
     ierr = cmor_get_cur_dataset_attribute( name, value );
-    if( ierr != 0 )
-	return NULL;
-    return(Py_BuildValue( "s", value ) );
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "get_cur_dataset_attribute");
+        return NULL;
+    }
+
+    return Py_BuildValue( "s", value );
 }
 
 /************************************************************************/
@@ -70,27 +100,43 @@ static PyObject *PyCMOR_get_cur_dataset_attribute( PyObject * self,
 /************************************************************************/
 static PyObject *PyCMOR_has_cur_dataset_attribute( PyObject * self,
 						   PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     char *name;
     int ierr;
 
     if( !PyArg_ParseTuple( args, "s", &name ) )
 	return NULL;
     ierr = cmor_has_cur_dataset_attribute( name );
+
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "has_cur_dataset_attribute");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", ierr );
 }
+
 /************************************************************************/
 /*                   PyCMOR_set_deflate()                    */
 /************************************************************************/
 static PyObject *PyCMOR_set_deflate( PyObject * self,
                                      PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, var_id, shuffle, deflate, deflate_level;
 
     if( !PyArg_ParseTuple( args, "iiii", &var_id, &shuffle, &deflate, &deflate_level ) )
         return NULL;
 
     ierr =  cmor_set_deflate( var_id, shuffle, deflate, deflate_level );
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "set_deflate");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", ierr );
-
 }
 
 /************************************************************************/
@@ -98,36 +144,47 @@ static PyObject *PyCMOR_set_deflate( PyObject * self,
 /************************************************************************/
 static PyObject *PyCMOR_set_variable_attribute( PyObject * self,
 						PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     char *name;
     char *value;
     int ierr, var_id;
 
     if( !PyArg_ParseTuple( args, "iss", &var_id, &name, &value ) )
 	return NULL;
+    
     ierr =
 	cmor_set_variable_attribute( var_id, name, 'c', ( void * ) value );
-    if( ierr != 0 )
-	return NULL;
-    /* Return NULL Python Object */
-    Py_INCREF( Py_None );
-    return Py_None;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "set_variable_attribute");
+        return NULL;
+    }
+    
+    return Py_BuildValue( "i", ierr );
 }
-
 
 /************************************************************************/
 /*                   PyCMOR_get_variable_attribute()                    */
 /************************************************************************/
 static PyObject *PyCMOR_get_variable_attribute( PyObject * self,
 						PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     char *name;
     char value[CMOR_MAX_STRING];
     int ierr, var_id;
 
     if( !PyArg_ParseTuple( args, "is", &var_id, &name ) )
 	return NULL;
+    
     ierr = cmor_get_variable_attribute( var_id, name, ( void * ) value );
-    if( ierr != 0 )
-	return NULL;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "get_variable_attribute");
+        return NULL;
+    }
+
     return Py_BuildValue( "s", value );
 }
 
@@ -136,12 +193,21 @@ static PyObject *PyCMOR_get_variable_attribute( PyObject * self,
 /************************************************************************/
 static PyObject *PyCMOR_has_variable_attribute( PyObject * self,
 						PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     char *name;
     int ierr, var_id;
 
     if( !PyArg_ParseTuple( args, "is", &var_id, &name ) )
 	return NULL;
+    
     ierr = cmor_has_variable_attribute( var_id, name );
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "has_variable_attribute");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", ierr );
 }
 
@@ -149,6 +215,7 @@ static PyObject *PyCMOR_has_variable_attribute( PyObject * self,
 /*                            PyCMOR_setup()                            */
 /************************************************************************/
 static PyObject *PyCMOR_setup( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int mode, ierr, netcdf, verbosity, createsub;
     char *path;
     char *logfile;
@@ -166,11 +233,14 @@ static PyObject *PyCMOR_setup( PyObject * self, PyObject * args ) {
 	    cmor_setup( path, &netcdf, &verbosity, &mode, logfile,
 			&createsub );
     }
-    if( ierr != 0 )
-	return NULL;
-    /* Return NULL Python Object */
-    Py_INCREF( Py_None );
-    return Py_None;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "setup");
+        return NULL;
+    }
+    
+    return Py_BuildValue( "i", ierr );
 }
 
 /************************************************************************/
@@ -268,6 +338,7 @@ static PyObject *PyCMOR_getFinalFilename( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_dataset_json( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr;
     char *rcfile;
 
@@ -276,11 +347,14 @@ static PyObject *PyCMOR_dataset_json( PyObject * self, PyObject * args ) {
     }
 
     ierr = cmor_dataset_json( rcfile );
-    if( ierr != 0 ) {
-        return Py_BuildValue( "i", ierr);
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "dataset_json");
+        return NULL;
     }
-
-    return Py_None;
+    
+    return Py_BuildValue( "i", ierr);
 }
 
 /************************************************************************/
@@ -288,15 +362,21 @@ static PyObject *PyCMOR_dataset_json( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_load_table( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, table_id;
     char *table;
 
     if( !PyArg_ParseTuple( args, "s", &table ) )
 	return NULL;
+    
     ierr = cmor_load_table( table, &table_id );
-    if( ierr != 0 ) {
-	return NULL;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "load_table");
+        return NULL;
     }
+
     return Py_BuildValue( "i", table_id );
 }
 
@@ -305,6 +385,7 @@ static PyObject *PyCMOR_load_table( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_axis( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, axis_id, n = 0;
     char *name;
     char *units;
@@ -389,13 +470,15 @@ static PyObject *PyCMOR_axis( PyObject * self, PyObject * args ) {
 	Py_DECREF( bounds );
     }
 
-    if( ierr != 0 )
-	return NULL;
-
     if( type == 'c' ) {
 	free( tmpstr );
     }
 
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "axis");
+        return NULL;
+    }
 
     return Py_BuildValue( "i", axis_id );
 }
@@ -405,22 +488,25 @@ static PyObject *PyCMOR_axis( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_set_table( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int table, ierr;
 
     if( !PyArg_ParseTuple( args, "i", &table ) )
 	return NULL;
+    
     ierr = cmor_set_table( table );
-    if( ierr != 0 )
-	return NULL;
-/* -------------------------------------------------------------------- */
-/*      Return NULL Python Object                                       */
-/* -------------------------------------------------------------------- */
-
-    Py_INCREF( Py_None );
-    return Py_None;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "set_table");
+        return NULL;
+    }
+    
+    return Py_BuildValue( "i", ierr);
 }
 
 static PyObject *PyCMOR_variable( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, var_id;
     char *name;
     char *units;
@@ -483,12 +569,18 @@ static PyObject *PyCMOR_variable( PyObject * self, PyObject * args ) {
     if( axes != NULL ) {
 	Py_DECREF( axes );
     }
-    if( ierr != 0 )
-	return NULL;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "variable");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", var_id );
 }
 
 static PyObject *PyCMOR_zfactor( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, zvar_id;
     int itmp;
     int axis_id;
@@ -558,13 +650,19 @@ static PyObject *PyCMOR_zfactor( PyObject * self, PyObject * args ) {
     if( bounds_array != NULL ) {
 	Py_DECREF( bounds_array );
     }
-    if( ierr != 0 )
-	return NULL;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "zfactor");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", zvar_id );
 }
 
 
 static PyObject *PyCMOR_grid_mapping( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr;
     PyObject *param_nm_obj, *param_val_obj, *param_un_obj, *tmp;
     PyArrayObject *param_val_arr = NULL;
@@ -605,13 +703,13 @@ static PyObject *PyCMOR_grid_mapping( PyObject * self, PyObject * args ) {
 	Py_DECREF( param_val_arr );
     }
 
-    if( ierr != 0 ) {
-	return NULL;
-    } else {
-	/* Return NULL Python Object */
-	Py_INCREF( Py_None );
-	return Py_None;
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "grid_mapping");
+        return NULL;
     }
+    
+    return Py_BuildValue( "i", ierr);
 }
 
 /************************************************************************/
@@ -619,6 +717,7 @@ static PyObject *PyCMOR_grid_mapping( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_write( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, var_id;
     PyObject *data_obj = NULL;
     PyArrayObject *data_array = NULL;
@@ -694,12 +793,13 @@ static PyObject *PyCMOR_write( PyObject * self, PyObject * args ) {
 	Py_DECREF( times_bnds_array );
     }
 
-    if( ierr != 0 )
-	return NULL;
-
-
-    Py_INCREF( Py_None );
-    return Py_None;
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "write");
+        return NULL;
+    }
+    
+    return Py_BuildValue( "i", ierr);
 }
 
 /************************************************************************/
@@ -707,6 +807,7 @@ static PyObject *PyCMOR_write( PyObject * self, PyObject * args ) {
 /************************************************************************/
 
 static PyObject *PyCMOR_close( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     PyObject *var;
     int varid, ierr;
     int dofile = 0;
@@ -745,8 +846,10 @@ static PyObject *PyCMOR_close( PyObject * self, PyObject * args ) {
 	}
     }
 
-    if( ierr != 0 ) {
-	return NULL;
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "close");
+        return NULL;
     } else {
 	if( dofile == 1 ) {
 	    return Py_BuildValue( "s", file_name );
@@ -762,6 +865,7 @@ static PyObject *PyCMOR_close( PyObject * self, PyObject * args ) {
 
 static PyObject *PyCMOR_time_varying_grid_coordinate( PyObject * self,
 						      PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr, grid_id, coord_var_id;
     char *table_entry;
     char *units;
@@ -786,8 +890,12 @@ static PyObject *PyCMOR_time_varying_grid_coordinate( PyObject * self,
 					   table_entry, units, type,
 					   pass_missing, NULL );
 
-    if( ierr != 0 )
-	return NULL;
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "time_varying_grid_coordinate");
+        return NULL;
+    }
+    
     return Py_BuildValue( "i", coord_var_id );
 }
 
@@ -796,6 +904,7 @@ static PyObject *PyCMOR_time_varying_grid_coordinate( PyObject * self,
 /************************************************************************/
 
 static PyObject *PyCMOR_grid( PyObject * self, PyObject * args ) {
+    signal(signal_to_catch, signal_handler);
     int ierr;
     PyObject *axes_obj, *lat_obj, *lon_obj, *blat_obj, *blon_obj;
     PyArrayObject *axes_arr = NULL, *lat_arr = NULL, *lon_arr =
@@ -875,11 +984,14 @@ static PyObject *PyCMOR_grid( PyObject * self, PyObject * args ) {
     if( blon_arr != NULL ) {
 	Py_DECREF( blon_arr );
     }
-    if( ierr != 0 )
-	return NULL;
+    
+    if (ierr != 0 || raise_exception) {
+        raise_exception = 0;
+        PyErr_Format(CMORError, message, "time_varying_grid_coordinate");
+        return NULL;
+    }
     return Py_BuildValue( "i", id );
 }
-
 
 static PyMethodDef MyExtractMethods[] = {
     {"setup", PyCMOR_setup, METH_VARARGS},
@@ -915,7 +1027,9 @@ static PyMethodDef MyExtractMethods[] = {
 };
 
 PyMODINIT_FUNC init_cmor( void ) {
-    ( void ) Py_InitModule( "_cmor", MyExtractMethods );
+    PyObject *cmor_module;
+    cmor_module = Py_InitModule("_cmor", MyExtractMethods);
     import_array(  );
-
+    CMORError = PyErr_NewException("cmor.CMORError", NULL, NULL);
+    PyModule_AddObject(cmor_module, "CMORError", CMORError);
 }

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -602,7 +602,7 @@ void cmor_handle_error( char error_msg[CMOR_MAX_STRING], int level ) {
     }
     if( ( CMOR_MODE == CMOR_EXIT_ON_WARNING )
 	|| ( level == CMOR_CRITICAL ) ) {
-        kill(getpid(), SIGINT);
+        kill(getpid(), SIGTERM);
     }
 }
 


### PR DESCRIPTION
Contrary to [my previous comment](https://github.com/PCMDI/cmor/issues/65#issuecomment-227139826), it is not possible to catch exceptions using the current version of CMOR. To test whether I could catch an exception when attempting to produce an output netCDF file for a variable and then go on to produce an output netCDF file for a second (different) variable, I added the following lines to the [CMIP6 example](https://github.com/PCMDI/cmor/blob/master/Test/test_python_CMIP6_experimentID.py) after the `cmor.load_table` call:

```
    try:
        print 'In try loop'
        ivar = cmor.variable(table_entry='soga', axis_ids=[], units='0.001')
    except BaseException as err:
        print 'In except loop'
        print err
    finally:
        print 'In finally loop'
    print 'Continuing'
```

When I run the edited example I get:

```
% ./example.py
In try loop

C Traceback:
! In function: cmor_variable
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: You are defining variable 'soga' (table Omon)  with 0 dimensions, when it should have 1
!
!!!!!!!!!!!!!!!!!!!!!!!!!

In finally loop
Traceback (most recent call last):
  File "./example.py", line 43, in <module>
    main()
  File "./example.py", line 28, in main
    ivar = cmor.variable(table_entry='soga', axis_ids=[], units='0.001')
KeyboardInterrupt
%
```

As you can see, the code doesn't get into the `except` loop (although the log message is printed at that time), and the exception is raised after the `finally` loop. This [stack overflow post](http://stackoverflow.com/questions/1717991/throwing-an-exception-from-within-a-signal-handler) says that "the signal handler runs with its own stack", which perhaps gives an indication why this is happening.

This pull request:

* raises a `CMORError` exception at the correct time
* removes the signal handler from `pywrapper.py` (it is no longer required, since the signal handling is done in `_cmormodule.c`)
* restores using a `SIGTERM` rather than a `SIGINT` (now that the signal is being handled appropriately, I don't see the core dumps any more)
* ensures the functions return the error code rather than None (I'm happy to update the documentation accordingly, if this pull request is merged)

I used the following sources when writing this code (my C is a little rusty):

* The signal handler: http://www.gnu.org/software/libc/manual/html_node/Handler-Returns.html#Handler-Returns
* Adding the new exception definition to the module's initialisation function: https://docs.python.org/2.7/extending/extending.html#intermezzo-errors-and-exceptions
* PyErr_Format: https://docs.python.org/2.7/c-api/exceptions.html#c.PyErr_Format

Running the edited example using this pull request:

```
% ./example.py
In try loop

C Traceback:
! In function: cmor_variable
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: You are defining variable 'soga' (table Omon)  with 0 dimensions, when it should have 1
!
!!!!!!!!!!!!!!!!!!!!!!!!!

In except loop
Problem with 'cmor.variable'. Please check the logfile (if defined).
In finally loop
Continuing
! ------
! CMOR is now closed.
! ------
! During execution we encountered:
!   0 Warning(s)
!   1 Error(s)
! ------
! Please review them.
! ------
! %
```

The output netCDF file for the `masso` variable is produced successfully.

I'm afraid I am still unable to run the tests (I still get an error), but I have done some limited testing and it seems to be behaving well. 