### PR TITLE
Correct access to the variable-specific realm value

### DIFF
--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -2506,11 +2506,13 @@ int cmor_setGblAttr(int var_id) {
     regex_t regex;
     int numchar;
     int nVarRefTblID;
+    int ref_var_id;
     int rc;
     int ierr=0;
 
     cmor_add_traceback("cmor_setGblAttr");
     nVarRefTblID = cmor_vars[var_id].ref_table_id;
+    ref_var_id = cmor_vars[var_id].ref_var_id;
 
     if( cmor_has_cur_dataset_attribute( GLOBAL_ATT_FORCING ) == 0 ) {
         cmor_get_cur_dataset_attribute( GLOBAL_ATT_FORCING, ctmp2 );
@@ -2630,14 +2632,14 @@ int cmor_setGblAttr(int var_id) {
 /* -------------------------------------------------------------------- */
 /*      first check if the variable itself has a realm                  */
 /* -------------------------------------------------------------------- */
-    if (cmor_tables[nVarRefTblID].vars[var_id].realm[0] != '\0') {
-        szToken = strtok(cmor_tables[nVarRefTblID].vars[var_id].realm, " ");
+    if (cmor_tables[nVarRefTblID].vars[ref_var_id].realm[0] != '\0') {
+        szToken = strtok(cmor_tables[nVarRefTblID].vars[ref_var_id].realm, " ");
         if( szToken != NULL){
             cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_REALM,
                     szToken, 0);
         } else {
             cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_REALM,
-                    cmor_tables[nVarRefTblID].vars[var_id].realm, 0);
+                    cmor_tables[nVarRefTblID].vars[ref_var_id].realm, 0);
         }
     } else {
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION
While testing CMOR 3.2.3, I discovered an issue related to accessing the variable-specific realm values from the MIP tables. This pull request fixes the issue.

Some details: `var_id` is used as an index for `cmor_vars`. However, it is not appropriate to use this index to access the appropriate variable from the MIP table (i.e. in `cmor_tables[nVarRefTblID].vars[var_id]`). 

In CMOR 3.2.2, `nVarRefTblID` was used in place of `var_id` as the index (see [here](https://github.com/PCMDI/cmor/blob/3.2.2/Src/cmor.c#L2624)). For the `Omon` and `SImon` tests I have, `nVarRefTblID` has a value of 0, meaning the realm value of the first variable in the MIP table was used. Coincidentally, the realm value of the first variable in the `Omon` and `SImon` MIP tables is the same as the realm value of the variables in my tests, so it appeared the realm was being set correctly (see #97). In CMOR 3.2.3, `var_id` is used as the index (see [here](https://github.com/PCMDI/cmor/blob/CMOR-3.2.3/Src/cmor.c#L2633)), which has a value of 4 for the tests I have. The fifth variable in the `Omon` MIP table has a realm value different to the realm value of the variables in my `Omon` tests, which is how I discovered the issue.