### PR TITLE
Added extra_link_args to Extension arguments

### DIFF
--- a/setup.py.in
+++ b/setup.py.in
@@ -10,6 +10,7 @@ include_dirs = [numpy.lib.utils.get_include(),"include","include/cdTime","includ
 library_dirs = [ os.path.join("@prefix@","lib") ,'.']
 include_dirs.append(os.path.join("@prefix@","include"))
 libraries = []
+link_args = []
 
 for st in ["@NCLDFLAGS@", "@NCCFLAGS@",  
            "@UDUNITS2FLAGS@", "@UDUNITS2LDFLAGS@",
@@ -22,6 +23,8 @@ for st in ["@NCLDFLAGS@", "@NCCFLAGS@",
         libraries.append(s[2:])
       if s[:2]=='-I':
         include_dirs.append(s[2:])
+      if s[:4]=='-Wl,':
+        link_args.append(s)
 
 srcfiles = "@LIBSOURCES@".split()
 srcfiles_CV = "@LIBSOURCESCV@".split()
@@ -65,7 +68,8 @@ setup (name = "CMOR",
                   library_dirs = library_dirs,
                   libraries = libraries,
                   define_macros = macros,
-                  extra_compile_args = [ "-DgFortran"]
+                  extra_compile_args = [ "-DgFortran"],
+                  extra_link_args = link_args
                   ),
             Extension('cmip6_cv._cmip6_cv',
                   srcfiles_CV,
@@ -73,7 +77,8 @@ setup (name = "CMOR",
                   library_dirs = library_dirs,
                   libraries = libraries,
                   define_macros = macros,
-                  extra_compile_args = [ "-DgFortran"]
+                  extra_compile_args = [ "-DgFortran"],
+                  extra_link_args = link_args
                   ),
         ],
        entry_points = {


### PR DESCRIPTION
extra_link_args -Wl,-rpath,/path/to/shared/libs may be passed by configure, but not used to build the python extension. As a result, the resulting .so binaries have no rpath to find shared libraries, and environmental LD_LIBRARY_PATH must be defined to locate them. This fix avoid the need to set LD_LIBRARY_PATH.