### PR TITLE
PrePARE call review

### DIFF
--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -554,7 +554,7 @@ class checkCMIP6(object):
                         for param, val1, val2 in values:
                             tmp[param] = [str('{}: {}'.format(param, val1)), str('{}: {}'.format(param, val2))]
                         table_values.extend([' '.join(i) for i in list(itertools.product(*tmp.values()))])
-                        if str(file_value) not in table_values:
+                        if str(file_value) not in map(str, table_values):
                             print BCOLORS.FAIL
                             print "====================================================================================="
                             print "Your file contains \"" + key + "\":\"" + str(file_value) + "\" and"
@@ -562,10 +562,9 @@ class checkCMIP6(object):
                             print "====================================================================================="
                             print BCOLORS.ENDC
                             self.cv_error = True
+                        continue
 
-                file_value = str(file_value)
-                table_value = str(table_value)
-                if table_value != file_value:
+                if str(table_value) != str(file_value):
                     print BCOLORS.FAIL
                     print "====================================================================================="
                     print "Your file contains \"" + key + "\":\"" + str(file_value) + "\" and"
@@ -577,7 +576,7 @@ class checkCMIP6(object):
                 # That attribute is not in the file
                 table_value = cv_attrs[key]
                 if key == "cell_measures":
-                    if (table_value.find("OPT") != -1) or (table_value.find("MODEL") != -1):
+                    if table_value.find("OPT") != -1 or table_value.find("MODEL") != -1:
                         continue
                 if isinstance(table_value, numpy.ndarray):
                     table_value = table_value[0]

--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -214,9 +214,9 @@ class checkCMIP6(object):
                 'Invalid JSON CMOR table: {}'.format(path))
 
     def setDoubleValue(self, attribute):
-        if (cmip6_cv.has_cur_dataset_attribute(attribute)):
-            if (isinstance(self.dictGbl[attribute], numpy.ndarray) and isinstance(self.dictGbl[attribute][0],
-                                                                                  numpy.float64)):
+        if cmip6_cv.has_cur_dataset_attribute(attribute):
+            if isinstance(self.dictGbl[attribute], numpy.ndarray) and isinstance(self.dictGbl[attribute][0],
+                                                                                 numpy.float64):
                 self.dictGbl[attribute] = self.dictGbl[attribute][0]
                 cmip6_cv.set_cur_dataset_attribute(
                     attribute, self.dictGbl[attribute])
@@ -266,9 +266,9 @@ class checkCMIP6(object):
             # If variable can be deduced from the filename (Default)
             self.variable = variable
         climatology = False
-        if (filename.find('-clim') != -1):
+        if filename.find('-clim') != -1:
             climatology = True
-            if (self.cmip6_table.find('Amon') != -1):
+            if self.cmip6_table.find('Amon') != -1:
                 self.variable = self.variable + 'Clim'
 
         # -------------------------------------------------------------------
@@ -310,7 +310,7 @@ class checkCMIP6(object):
         if climatology and climPos != -1:
             self.var = [self.var[0][:climPos]]
 
-        if ((self.var == []) or (len(self.var) > 1)):
+        if (self.var == []) or (len(self.var) > 1):
             print bcolors.FAIL
             print "!!!!!!!!!!!!!!!!!!!!!!!!!"
             print "! Error:  The input file does not have an history attribute and the CMIP6 variable could not be found"
@@ -449,22 +449,22 @@ class checkCMIP6(object):
         # -----------------------------
         prepLIST = cmip6_cv.list_variable_attributes(varid)
         for key in prepLIST:
-            if (key == "long_name"):
+            if key == "long_name":
                 continue
-            if (key == "comment"):
+            if key == "comment":
                 continue
             # Is this attribute in file?
-            if (key in self.dictVars.keys()):
+            if key in self.dictVars.keys():
                 # Verify that attribute value is equal to file attribute
                 table_value = prepLIST[key]
                 file_value = self.dictVars[key]
 
                 # PrePARE accept units of 1 or 1.0 so adjust thet table_value
                 # -----------------------------------------------------------
-                if (key == "units"):
-                    if ((table_value == "1") and (file_value == "1.0")):
+                if key == "units":
+                    if (table_value == "1") and (file_value == "1.0"):
                         table_value = "1.0"
-                    if ((table_value == "1.0") and (file_value == "1")):
+                    if (table_value == "1.0") and (file_value == "1"):
                         table_value = "1"
 
                 if isinstance(table_value, str) and isinstance(file_value, numpy.ndarray):
@@ -503,7 +503,7 @@ class checkCMIP6(object):
                 # That attribute is not in the file
                 table_value = prepLIST[key]
                 if key == "cell_measures":
-                    if ((table_value.find("OPT") != -1) or (table_value.find("MODEL") != -1)):
+                    if (table_value.find("OPT") != -1) or (table_value.find("MODEL") != -1):
                         continue
                 if isinstance(table_value, numpy.ndarray):
                     table_value = table_value[0]

--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -11,12 +11,14 @@
 #   python CMIP6Validtor ../Tables/CMIP6_Amon.json ../CMIP6/yourfile.nc
 #
 
-'''
+"""
 Created on Fri Feb 19 11:33:52 2016
 
 @author: Denis Nadeau LLNL
 @co-author: Guillaume Levavasseur (IPSL) Parallelization
-'''
+
+"""
+
 import re
 import sys
 from contextlib import contextmanager
@@ -176,7 +178,6 @@ class Spinner:
         sys.stdout.flush()
         Spinner.step += 1
 
-
 # =========================
 # checkCMIP6()
 # =========================
@@ -203,13 +204,17 @@ class checkCMIP6(object):
     # *************************
     def __init__(self, table_path):
         # -------------------------------------------------------------------
-        #  Initilaze table path
+        #  Reset CV error switch
+        # -------------------------------------------------------------------
+        self.cv_error = False
+        # -------------------------------------------------------------------
+        #  Initialize table path
         # -------------------------------------------------------------------
         self.cmip6_table_path = os.path.normpath(table_path)
         # -------------------------------------------------------------------
         # call setup() to clean all 'C' internal memory.
         # -------------------------------------------------------------------
-        cmip6_cv.setup(inpath="../Tables", exit_control=cmip6_cv.CMOR_NORMAL)
+        cmip6_cv.setup(inpath=". ./Tables", exit_control=cmip6_cv.CMOR_NORMAL)
         # -------------------------------------------------------------------
         # Set Control Vocabulary file to use (default from cmor.h)
         # -------------------------------------------------------------------
@@ -422,7 +427,7 @@ class checkCMIP6(object):
             print " Could not find variable '%s' in table '%s' " % (self.var[0], self.cmip6_table)
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
             raise KeyboardInterrupt
 
         fn = os.path.basename(str(self.infile).split('\'')[1])
@@ -439,7 +444,7 @@ class checkCMIP6(object):
             print "branch_time_in_child is not a double: ", type(self.dictGbl['branch_time_in_child'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            CV_ERROR = True
 
         if not isinstance(self.dictGbl['branch_time_in_parent'], numpy.float64):
             print bcolors.FAIL
@@ -447,7 +452,7 @@ class checkCMIP6(object):
             print "branch_time_in_parent is not an double: ", type(self.dictGbl['branch_time_in_parent'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
 
         if not isinstance(self.dictGbl['realization_index'], numpy.ndarray):
             print bcolors.FAIL
@@ -455,7 +460,7 @@ class checkCMIP6(object):
             print "realization_index is not an integer: ", type(self.dictGbl['realization_index'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
 
         if not isinstance(self.dictGbl['initialization_index'], numpy.ndarray):
             print bcolors.FAIL
@@ -463,7 +468,7 @@ class checkCMIP6(object):
             print "initialization_index is not an integer: ", type(self.dictGbl['initialization_index'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
 
         if not isinstance(self.dictGbl['physics_index'], numpy.ndarray):
             print bcolors.FAIL
@@ -471,7 +476,7 @@ class checkCMIP6(object):
             print "physics_index is not an integer: ", type(self.dictGbl['physics_index'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
 
         if not isinstance(self.dictGbl['forcing_index'], numpy.ndarray):
             print bcolors.FAIL
@@ -479,7 +484,7 @@ class checkCMIP6(object):
             print "forcing_index is not an integer: ", type(self.dictGbl['forcing_index'])
             print "====================================================================================="
             print bcolors.ENDC
-            cmip6_cv.set_CV_Error()
+            self.cv_error = True
 
         # -----------------------------
         # variable attribute comparison
@@ -542,8 +547,7 @@ class checkCMIP6(object):
                             print "CMIP6 tables requires \"" + key + "\":\"" + str(table_value) + "\"."
                             print "====================================================================================="
                             print bcolors.ENDC
-                            cmip6_cv.set_CV_Error()
-
+                            self.cv_error = True
 
                 file_value = str(file_value)
                 table_value = str(table_value)
@@ -554,7 +558,7 @@ class checkCMIP6(object):
                     print "CMIP6 tables requires \"" + key + "\":\"" + str(table_value) + "\"."
                     print "====================================================================================="
                     print bcolors.ENDC
-                    cmip6_cv.set_CV_Error()
+                    self.cv_error = True
             else:
                 # That attribute is not in the file
                 table_value = prepLIST[key]
@@ -570,9 +574,9 @@ class checkCMIP6(object):
                 print "CMIP6 variable " + self.var[0] + " requires \"" + key + "\":\"" + str(table_value) + "\"."
                 print "====================================================================================="
                 print bcolors.ENDC
-                cmip6_cv.set_CV_Error()
+                self.cv_error = True
 
-        if (cmip6_cv.get_CV_Error()):
+        if self.cv_error:
             raise KeyboardInterrupt
         else:
             print bcolors.OKGREEN


### PR DESCRIPTION
- `--table-path` can be a full JSON path or the table directory. If a directory, the CMOR table is deduced from filename
- `--variable` is optional. If not submitted, the variable is deduced from filename
- `--table-path` and `--variable` cab be used in sequential or multiprocessing mode. With multiprocessing, pay attention to scan files corresponding to the same CMOR table and/or variable if the flags are used.
- bugfix on logfile in multiprocessing mode: now print statements are "append" to logfile instead of truncate the logfile (all file diagnostics are now returned at the end of the multiprocessing file checkup).
- code has been simplified, reformatted and cleaned.