### PR TITLE
392 ignore cmor_locale.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ config.status
 Tables_csv/standard_output.xls
 autom4te.cache
 setup.py
+include/cmor_locale.h

--- a/include/cmor_locale.h
+++ b/include/cmor_locale.h
@@ -1,4 +1,0 @@
-#ifndef _CMOR_LOCALE
-#define _CMOR_LOCALE
-#define CMOR_PREFIX  "/home/doutriaux1/anaconda2/envs/cmor"
-#endif


### PR DESCRIPTION
Removed inlcude/cmor_locale.h, which has been added to .gitignore. 