### PR TITLE
Fixed test_cmor_grid_unstructured_fabi.c

### DIFF
--- a/Test/test_cmor_grid_unstructured_fabi.c
+++ b/Test/test_cmor_grid_unstructured_fabi.c
@@ -67,11 +67,11 @@ int main()
             /* vertices lon */
             for (vert = 0; vert < nvert; vert++)
               {
-                lon_vertices[j * ind + nvert] =
-                  lon_coords[j * ind];
+                lon_vertices[j * nvert + vert] =
+                    lon_coords[j];
                 /* vertices lat */
-                lat_vertices[j * ind + nvert] =
-                  lat_coords[j * ind];
+                lat_vertices[j * nvert + vert] =
+                    lat_coords[j];
               }
         }
 


### PR DESCRIPTION
The long_coords and lat_coords arrays were being accessed out-of-bounds, and lon_vertices and lat_vertices didn't look like they were being accessed correctly.