### PR TITLE
Use CMOR_RECIPE_DIR to point conda_upload.sh to the recipe directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ after_failure:
   - cat ~/build.sh
 
 after_success:
-  - if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_OS_NAME == "osx" ]]; then bash scripts/conda_upload.sh ${TRAVIS_BRANCH} ; fi
-  - if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_OS_NAME == "linux" ]]; then docker run -v `pwd`:/travis_home -e CONDA_UPLOAD_TOKEN=${CONDA_UPLOAD_TOKEN} -e CMOR_PYTHON_VERSION=${CMOR_PYTHON_VERSION} -a STDOUT -a STDERR centos:6.8 /travis_home/scripts/conda_upload.sh ${TRAVIS_BRANCH} ; fi
+  - if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_OS_NAME == "osx" ]]; then CMOR_RECIPE_DIR=recipes bash scripts/conda_upload.sh ${TRAVIS_BRANCH} ; fi
+  - if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_OS_NAME == "linux" ]]; then docker run -v `pwd`:/travis_home -e CONDA_UPLOAD_TOKEN=${CONDA_UPLOAD_TOKEN} -e CMOR_RECIPE_DIR=/travis_home/recipes -e CMOR_PYTHON_VERSION=${CMOR_PYTHON_VERSION} -a STDOUT -a STDERR centos:6.8 /travis_home/scripts/conda_upload.sh ${TRAVIS_BRANCH} ; fi

--- a/scripts/conda_upload.sh
+++ b/scripts/conda_upload.sh
@@ -44,7 +44,7 @@ fi
 export CONDA_BLD_PATH=${HOME}/conda-bld
 export VERSION=`date +%Y.%m.%d`
 export UVCDAT_ANONYMOUS_LOG=no
-cd recipes
+cd ${CMOR_RECIPE_DIR}
 cmorversion=`echo $1 | cut -d- -f2`
 python ./prep_for_build.py -v `date +%Y.%m.%d`.${cmorversion} -b $1
 echo "Building now"


### PR DESCRIPTION
When running the Travis builds, the home directory of the Docker containers isn't the same as the cmor directory.  This makes conda_uploads.sh not go to the recipes directory, which would be in /travis_home/recipes in the container.  This PR adds the variable CMOR_RECIPE_DIR for conda_upload.sh to find the recipe directory.