### PR TITLE
Add libnetcdf 4.6.2 to the run requirements of meta.yaml.in

### DIFF
--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -38,7 +38,7 @@ requirements:
     - json-c
     - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('hdf5') }}
-    - {{ pin_compatible('libnetcdf') }}
+    - libnetcdf 4.6.2
     - cdms2
 
 about:


### PR DESCRIPTION
I forgot to add libnetcdf 4.6.2 to the run requirements of meta.yaml.in.  This prevented the nightly builds from being uploaded.