### PR TITLE
Replace cdms2 with netCDF4 in PrePARE and Python tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner cdms2
 
   - &setup_cmor
     name: setup_cmor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner cdms2
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor
@@ -48,6 +48,9 @@ aliases:
        set +e
        source activate py$PYTHON_VERSION
        set -e
+       make test
+       # run tests again but with cdms2 installed
+       conda install -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat cdms2
        make test
   - &run_prepare_tests
     name: run_prepare_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 numpy openssl lazy-object-proxy cdms2 python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ install:
 
 script:
   - make test
+  - conda install -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat cdms2
+  - make test
   - export PYTHONPATH=Test/:$PYTHONPATH
   - python run_tests.py -v2 -n1 -H Test/test_python_CMIP6_CV*.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 numpy openssl lazy-object-proxy cdms2 python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner cdms2
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner cdms2
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -71,9 +71,9 @@ def time_varying_grid_coordinate(
     if not isinstance(units, six.string_types):
         raise Exception("Error you must pass a string for the variable units")
     if not isinstance(type, six.string_types):
-        raise Exception("error tpye must a a string")
+        raise Exception("error type must be a string")
     type = type.lower()
-    if type == 's':
+    if type == 's' or type == 'u':
         type = 'c'
     if type not in ["c", "d", "f", "l", "i"]:
         raise Exception(
@@ -424,10 +424,10 @@ def axis(table_entry, units=None, length=None,
         l = len(coord_vals)
         type = coord_vals.dtype.char[0]
 
-        if not type in ['i', 'l', 'f', 'd', 'S']:
+        if not type in ['i', 'l', 'f', 'd', 'S', 'U']:
             raise Exception("error allowed data type are: i,l,f,d or S")
 
-        if type == 'S':
+        if type == 'S' or type == 'U':
             type = 'c'
             cbnds = 0
             for s in coord_vals:
@@ -507,9 +507,9 @@ def variable(table_entry, units, axis_ids, type='f', missing_value=None,
         raise Exception("error axis_ids list/array must be 1D")
 
     if not isinstance(type, six.string_types):
-        raise Exception("error tpye must a a string")
+        raise Exception("error type must be a string")
     type = type.lower()
-    if type == 's':
+    if type == 's' or type == 'u':
         type = 'c'
     if not type in ["c", "d", "f", "l", "i"]:
         raise Exception(
@@ -632,9 +632,9 @@ def zfactor(zaxis_id, zfactor_name, units="", axis_ids=None,
         type = 'd'
 
     if not isinstance(type, six.string_types):
-        raise Exception("error type must a string")
+        raise Exception("error type must be a string")
     type = type.lower()
-    if type == 's':
+    if type == 's' or type == 'u':
         type = 'c'
     if not type in ["c", "d", "f", "l", "i"]:
         raise Exception(

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -79,14 +79,15 @@ def time_varying_grid_coordinate(
         raise Exception(
             'error unknown type: "%s", must be one of: "c","d","f","l","i"')
 
-    if not isinstance(grid_id, (int, numpy.int, numpy.int32)):
+    if not isinstance(grid_id, (int, numpy.int, numpy.int32, numpy.int64)):
         raise Exception("error grid_id must be an integer")
 
     grid_id = int(grid_id)
 
     if missing_value is not None:
-        if not isinstance(missing_value, (float, int, numpy.float,
-                                          numpy.float32, numpy.int, numpy.int32)):
+        if not isinstance(missing_value, (float, int, 
+                                          numpy.float, numpy.float32, numpy.float64, 
+                                          numpy.int, numpy.int32, numpy.int64)):
             raise Exception(
                 "error missing_value must be a number, you passed: %s" %
                 type(missing_value))
@@ -242,11 +243,12 @@ def set_grid_mapping(grid_id, mapping_name, parameter_names,
        parameter_units  :: array/list of parameter units  in the same order of parameter_names (ignored if parameter_names is ditcionary)
     """
     if sys.version_info < (3, 0):
-        if not isinstance(grid_id, (numpy.int32, int, long)):
+        if not isinstance(grid_id, (numpy.int32, numpy.int64, int, long)):
             raise Exception("grid_id must be an integer: %s" % type(grid_id))
     else:
-        if not isinstance(grid_id, (numpy.int32, int)):
+        if not isinstance(grid_id, (numpy.int32, numpy.int64, int)):
             raise Exception("grid_id must be an integer: %s" % type(grid_id))
+        grid_id = int(grid_id)
     if not isinstance(mapping_name, six.string_types):
         raise Exception("mapping name must be a string")
 
@@ -532,15 +534,17 @@ def variable(table_entry, units, axis_ids, type='f', missing_value=None,
     else:
         comment = str(comment)
 
-    if not isinstance(tolerance, (float, int, numpy.float,
-                                  numpy.float32, numpy.int, numpy.int32)):
+    if not isinstance(tolerance, (float, int, 
+                                  numpy.float, numpy.float32, numpy.float64, 
+                                  numpy.int, numpy.int32, numpy.int64)):
         raise Exception("error tolerance must be a number")
 
     tolerance = float(tolerance)
 
     if missing_value is not None:
-        if not isinstance(missing_value, (float, int, numpy.float,
-                                          numpy.float32, numpy.int, numpy.int32)):
+        if not isinstance(missing_value, (float, int,
+                                          numpy.float, numpy.float32, numpy.float64, 
+                                          numpy.int, numpy.int32, numpy.int64)):
             raise Exception(
                 "error missing_value must be a number, you passed: %s" %
                 repr(missing_value))
@@ -555,7 +559,7 @@ def variable(table_entry, units, axis_ids, type='f', missing_value=None,
 def zfactor(zaxis_id, zfactor_name, units="", axis_ids=None,
             type=None, zfactor_values=None, zfactor_bounds=None):
 
-    if not isinstance(zaxis_id, (int, numpy.int, numpy.int32)):
+    if not isinstance(zaxis_id, (int, numpy.int, numpy.int32, numpy.int64)):
         raise Exception("error zaxis_id must be a number")
     zaxis_id = int(zaxis_id)
 
@@ -578,7 +582,7 @@ def zfactor(zaxis_id, zfactor_name, units="", axis_ids=None,
         axis_ids = numpy.ascontiguousarray(axis_ids)
     elif axis_ids is None:
         pass
-    elif isinstance(axis_ids, (int, numpy.int, numpy.int32)):
+    elif isinstance(axis_ids, (int, numpy.int, numpy.int32, numpy.int64)):
         axis_ids = numpy.array([axis_ids, ])
     elif not isinstance(axis_ids, numpy.ndarray):
         raise Exception(
@@ -683,7 +687,7 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
     Usage:
     ierr = write(var_id,data,ntimes_passed=None,file_suffix="",time_vals=None,time_bnds=None,store_with=None
     """
-    if not isinstance(var_id, (int, numpy.int, numpy.int32)):
+    if not isinstance(var_id, (int, numpy.int, numpy.int32, numpy.int64)):
         raise Exception("error var_id must be an integer")
     var_id = int(var_id)
 
@@ -691,7 +695,7 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
         raise Exception("Error file_suffix must be a string")
 
     if store_with is not None:
-        if not isinstance(store_with, (int, numpy.int, numpy.int32)):
+        if not isinstance(store_with, (int, numpy.int, numpy.int32, numpy.int64)):
             raise Exception("error store_with must be an integer")
         store_with = int(store_with)
 
@@ -741,7 +745,7 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
             ntimes_passed = 0
         else:
             ntimes_passed = len(time_vals)
-    if not isinstance(ntimes_passed, (int, numpy.int, numpy.int32)):
+    if not isinstance(ntimes_passed, (int, numpy.int, numpy.int32, numpy.int64)):
         raise Exception("error ntimes_passed must be an integer")
     ntimes_passed = int(ntimes_passed)
 

--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -457,7 +457,7 @@ class checkCMIP6(object):
         for attr in ['branch_time_in_child', 'branch_time_in_parent']:
             if attr in list(self.dictGbl.keys()):
                 self.set_double_value(attr)
-                if not isinstance(self.dictGbl[attr], numpy.float64):
+                if not numpy.issubdtype(self.dictGbl[attr], numpy.float64):
                     print(BCOLORS.FAIL)
                     print("=====================================================================================")
                     print("{} is not a double: ".format(attr), type(self.dictGbl[attr]))
@@ -465,7 +465,7 @@ class checkCMIP6(object):
                     print(BCOLORS.ENDC)
                     self.errors += 1
         for attr in ['realization_index', 'initialization_index', 'physics_index', 'forcing_index']:
-            if not isinstance(self.dictGbl[attr], numpy.ndarray):
+            if not numpy.issubdtype(self.dictGbl[attr], numpy.integer):
                 print(BCOLORS.FAIL)
                 print("=====================================================================================")
                 print("{} is not an integer: ".format(attr), type(self.dictGbl[attr]))
@@ -535,7 +535,7 @@ class checkCMIP6(object):
         # -------------------------------------------------------------------
         varid = cmip6_cv.setup_variable(variable_cmor_entry,
                                         self.dictVar['units'],
-                                        self.dictVar['_FillValue'][0],
+                                        self.dictVar['_FillValue'],
                                         startime,
                                         endtime,
                                         startimebnds,

--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -33,8 +33,8 @@ from multiprocessing import Pool
 from uuid import uuid4 as uuid
 
 import numpy
+import netCDF4
 
-from cdms2 import Cdunif
 import cmip6_cv
 
 
@@ -384,7 +384,7 @@ class checkCMIP6(object):
         #  Open file in processing
         #  The file needs to be open before the calling the test.
         # -------------------------------------------------------------------
-        infile = Cdunif.CdunifFile(ncfile, "r")
+        infile = netCDF4.Dataset(ncfile, "r")
         key = '{}_{}'.format(table_id, variable_id)
         variable_cmor_entry = None
         if key in list(out_names_tests.keys()):

--- a/Makefile.in
+++ b/Makefile.in
@@ -206,7 +206,7 @@ test_python: python
 	env TEST_NAME=Test/test_python_grid_and_ocn_sigma.py make test_a_python
 	env TEST_NAME=Test/test_python_jamie_site_surface.py make test_a_python
 #	env TEST_NAME=Test/test_python_max_variables.py make test_a_python
-	env TEST_NAME=Test/test_python_max_variables_2.py make test_a_python
+#	env TEST_NAME=Test/test_python_max_variables_2.py make test_a_python
 	env TEST_NAME=Test/test_python_reverted_lats.py make test_a_python
 	env TEST_NAME=Test/test_lon_gt_360.py make test_a_python
 	env TEST_NAME=Test/test_lon_thro_360.py make test_a_python

--- a/Makefile.in
+++ b/Makefile.in
@@ -205,7 +205,7 @@ test_python: python
 #	env TEST_NAME=Test/test_python_fx.py make test_a_python
 	env TEST_NAME=Test/test_python_grid_and_ocn_sigma.py make test_a_python
 	env TEST_NAME=Test/test_python_jamie_site_surface.py make test_a_python
-	env TEST_NAME=Test/test_python_max_variables.py make test_a_python
+#	env TEST_NAME=Test/test_python_max_variables.py make test_a_python
 	env TEST_NAME=Test/test_python_max_variables_2.py make test_a_python
 	env TEST_NAME=Test/test_python_reverted_lats.py make test_a_python
 	env TEST_NAME=Test/test_lon_gt_360.py make test_a_python

--- a/Makefile.in
+++ b/Makefile.in
@@ -124,8 +124,8 @@ backup: clean
 	@tar cfz $$TGZNAME Cmor; \
 	@touch $(TIMESTAMPDIR)/cmor_`$(TIMESTAMP)`_full.time; \
 	@echo "Full backup tar file created : $$TGZNAME")
-test:  cmor test_C @TEST_FORTRAN@ @MAKETESTPYTHON@
-	@echo "All C and Fortran Test passed successfully"
+test:  cmor test_C @TEST_FORTRAN@ test_python
+	@echo "All C, Fortran, and Python tests passed successfully"
 test_C: cmor 
 	rm -f ./ipcc_test_code ; @CC@ @CFLAGS@ @USERCFLAGS@ @CPPFLAGS@  Test/ipcc_test_code.c -L@prefix@/lib -I@prefix@/include  -L. -lcmor @NCCFLAGS@ @NCLDFLAGS@ @UDUNITS2LDFLAGS@ @UDUNITS2FLAGS@ @JSONCLDFLAGS@ @JSONCFLAGS@ @UUIDLDFLAGS@ @UUIDFLAGS@ @LDFLAGS@  -o ipcc_test_code  @VERB@; ./ipcc_test_code @VERB@
 	rm -f ./test_singletons ; @CC@ @CFLAGS@ @USERCFLAGS@ @CPPFLAGS@  Test/test_singletons.c -L@prefix@/lib -I@prefix@/include  -L. -lcmor @NCCFLAGS@ @NCLDFLAGS@ @UDUNITS2LDFLAGS@ @UDUNITS2FLAGS@ @JSONCLDFLAGS@ @JSONCFLAGS@ @UUIDLDFLAGS@ @UUIDFLAGS@ @LDFLAGS@  -o test_singletons  @VERB@; ./test_singletons @VERB@
@@ -148,10 +148,10 @@ test_a_python:
 	@echo "${OK_COLOR}Testing ${TEST_NAME} ${NO_COLOR}"
 	${PYTHONEXEC} ${TEST_NAME} ${VERB}
 test_python: python
-	env TEST_NAME=Test/test_python_climatology.py make test_a_python
+	# [missing] env TEST_NAME=Test/test_python_climatology.py make test_a_python
 	env TEST_NAME=Test/test_python_history.py make test_a_python
-	env TEST_NAME=Test/test_python_historydefault.py make test_a_python
-	env TEST_NAME=Test/test_python_test_write.py make test_a_python
+	# [missing] env TEST_NAME=Test/test_python_historydefault.py make test_a_python
+	# [missing] env TEST_NAME=Test/test_python_test_write.py make test_a_python
 	env TEST_NAME=Test/test_python_missing_values.py make test_a_python
 	env TEST_NAME=Test/test_python_history.py make test_a_python
 	env TEST_NAME=Test/test_python_sos_psu_units.py make test_a_python
@@ -198,8 +198,6 @@ test_python: python
 	env TEST_NAME=Test/jamie_hybrid_height.py make test_a_python
 	env TEST_NAME=Test/jamie_positive.py make test_a_python
 	env TEST_NAME=Test/test_python_1D_var.py make test_a_python
-	env TEST_NAME=Test/test_python_2Gb_file.py make test_a_python
-	env TEST_NAME=Test/test_python_2Gb_slice.py make test_a_python
 #	env TEST_NAME=Test/test_python_3hr.py make test_a_python
 	env TEST_NAME=Test/test_python_YYYMMDDHH_exp_fmt.py make test_a_python
 #	@env TEST_NAME=Test/test_python_alastair_1.py make test_a_python
@@ -221,6 +219,9 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_half_levels_with_bounds.py make test_a_python
 	env TEST_NAME=Test/test_cmor_half_levels_wrong_generic_level.py make test_a_python
 	env TEST_NAME=Test/test_cmor_double_singleton.py make test_a_python
+test_python_2gb:
+	env TEST_NAME=Test/test_python_2Gb_file.py make test_a_python
+	env TEST_NAME=Test/test_python_2Gb_slice.py make test_a_python
 
 test_case:
 	@echo "${OK_COLOR}Testing: "${TEST_NAME}" with input file: ${INPUT_FILE}${NO_COLOR}"

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -170,8 +170,8 @@ static PyObject *PyCMOR_set_variable_attribute(PyObject * self, PyObject * args)
         return NULL;
 
 #if PY_MAJOR_VERSION >= 3
-    if(PyBytes_Check(oValue)) {
-        value = PyBytes_AsString(oValue);
+    if(PyUnicode_Check(oValue)) {
+        value = PyUnicode_AsUTF8(oValue);
 #else
     if(PyString_Check(oValue)) {
         value = PyString_AsString(oValue);
@@ -753,14 +753,14 @@ static PyObject *PyCMOR_grid_mapping(PyObject * self, PyObject * args)
     for (i = 0; i < n; i++) {
         tmp = PyList_GetItem(param_nm_obj, i);
 #if PY_MAJOR_VERSION >= 3
-        strcpy(nms[i], PyBytes_AsString(tmp));
+        strcpy(nms[i], PyUnicode_AsUTF8(tmp));
 #else
         strcpy(nms[i], PyString_AsString(tmp));
 #endif
         //Py_DECREF(tmp); //Not needed get_item does not increase ref
         tmp = PyList_GetItem(param_un_obj, i);
 #if PY_MAJOR_VERSION >= 3
-        strcpy(units[i], PyBytes_AsString(tmp));
+        strcpy(units[i], PyUnicode_AsUTF8(tmp));
 #else
         strcpy(units[i], PyString_AsString(tmp));
 #endif

--- a/Test/cmor_speed_and_compression.py
+++ b/Test/cmor_speed_and_compression.py
@@ -136,7 +136,7 @@ import os
 ltime = cdtime.reltime(ntimes - 1, 'month since 1980').tocomp()
 #lcmor = os.stat("CMIP6/CMIP/CSIRO-BOM/NICAM/piControl/r1i1p1f1/Amon/tas/gn/v%s/tas_Amon_piControl_NICAM_r1i1p1f1_gn_198001-%i%.2i.nc" % (today,ltime.year,ltime.month))[6]
 lcmor = os.stat(
-    "CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Amon/tas/gr/v%s/tas_Amon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_198001-%i%.2i.nc" %
+    "CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Amon/tas/gn/v%s/tas_Amon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_198001-%i%.2i.nc" %
     (today, ltime.year, ltime.month))[6]
 print('level:', level, "shuffle:", shuffle)
 print('total cmor:', totcmor, mincmor, totcmor / ntimes, maxcmor, lcmor)

--- a/Test/cmor_speed_and_compression_01.py
+++ b/Test/cmor_speed_and_compression_01.py
@@ -122,7 +122,7 @@ import os
 ltime = cdtime.reltime(ntimes - 1, 'month since 1980').tocomp()
 #lcmor = os.stat("CMIP6/CMIP/CSIRO-BOM/NICAM/piControl/r1i1p1f1/Amon/tas/gn/v%s/tas_Amon_piControl_NICAM_r1i1p1f1_gn_197901-197912.nc"%(today))[6]
 lcmor = os.stat(
-    "CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Amon/tas/gr/v%s/tas_Amon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_197901-197912.nc" % (today))[6]
+    "CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Amon/tas/gn/v%s/tas_Amon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_197901-197912.nc" % (today))[6]
 print('level:', level, "shuffle:", shuffle)
 print('total cmor:', totcmor, mincmor, totcmor / ntimes, maxcmor, lcmor)
 lcdms = os.stat("Test/crap.nc")[6]

--- a/Test/common.py
+++ b/Test/common.py
@@ -112,3 +112,27 @@ def read_cmor_time_lat_lon():
         units="days since 1850",
         length=ntimes)
     return itim, ilat, ilon
+
+def read_cmor_time1_lat_lon():
+    ilat = cmor.axis(
+        table_entry='latitude',
+        units='degrees_north',
+        length=lat,
+        coord_vals=alats,
+        cell_bounds=bnds_lat)
+    print("ILAT:", ilat)
+    print(lon, alons, bnds_lon)
+    ilon = cmor.axis(
+        table_entry='longitude',
+        coord_vals=alons,
+        units='degrees_east',
+        cell_bounds=bnds_lon)
+
+    print("ILON:", ilon)
+
+
+    itim = cmor.axis(
+        table_entry="time1",
+        units="days since 1850",
+        length=ntimes)
+    return itim, ilat, ilon

--- a/Test/test_cmor_double_singleton.py
+++ b/Test/test_cmor_double_singleton.py
@@ -7,7 +7,7 @@ import os
 pth = os.getcwd()
 common.init_cmor(pth, "CMOR_input_example.json")
 cmor.load_table(os.path.join(pth, 'Tables', 'CMIP6_6hrLev.json'))
-itim, ilat, ilon = common.read_cmor_time_lat_lon()
+itim, ilat, ilon = common.read_cmor_time1_lat_lon()
 
 ilambda = cmor.axis(
     table_entry='lambda550nm',

--- a/Test/test_cmor_half_levels.py
+++ b/Test/test_cmor_half_levels.py
@@ -1,9 +1,18 @@
 from __future__ import print_function
-import cdms2
 import cmor
 import numpy
 import os
+import sys
 import common
+
+try:
+    import cdms2
+    cdms2.setNetcdfShuffleFlag(0)
+    cdms2.setNetcdfDeflateFlag(0)
+    cdms2.setNetcdfDeflateLevelFlag(0)
+except BaseException:
+    print("This test code needs a recent cdms2 interface for i/0")
+    sys.exit()
 
 varin3d = ["MC", ]
 

--- a/Test/test_cmor_half_levels.py
+++ b/Test/test_cmor_half_levels.py
@@ -5,15 +5,6 @@ import os
 import sys
 import common
 
-try:
-    import cdms2
-    cdms2.setNetcdfShuffleFlag(0)
-    cdms2.setNetcdfDeflateFlag(0)
-    cdms2.setNetcdfDeflateLevelFlag(0)
-except BaseException:
-    print("This test code needs a recent cdms2 interface for i/0")
-    sys.exit()
-
 varin3d = ["MC", ]
 
 n3d = len(varin3d)

--- a/Test/test_cmor_half_levels_with_bounds.py
+++ b/Test/test_cmor_half_levels_with_bounds.py
@@ -1,8 +1,17 @@
 from __future__ import print_function
-import cdms2
 import cmor
 import numpy
 import os
+import sys
+
+try:
+    import cdms2
+    cdms2.setNetcdfShuffleFlag(0)
+    cdms2.setNetcdfDeflateFlag(0)
+    cdms2.setNetcdfDeflateLevelFlag(0)
+except BaseException:
+    print("This test code needs a recent cdms2 interface for i/0")
+    sys.exit()
 
 specs = {"CLOUD": {"convert": [2.0, 0.], "units": "%", "entry": "cl", "positive": ""},
          "U": {"convert": [1., -40.], "units": "m s-1", "entry": "ua", "positive": ""},

--- a/Test/test_cmor_half_levels_with_bounds.py
+++ b/Test/test_cmor_half_levels_with_bounds.py
@@ -4,15 +4,6 @@ import numpy
 import os
 import sys
 
-try:
-    import cdms2
-    cdms2.setNetcdfShuffleFlag(0)
-    cdms2.setNetcdfDeflateFlag(0)
-    cdms2.setNetcdfDeflateLevelFlag(0)
-except BaseException:
-    print("This test code needs a recent cdms2 interface for i/0")
-    sys.exit()
-
 specs = {"CLOUD": {"convert": [2.0, 0.], "units": "%", "entry": "cl", "positive": ""},
          "U": {"convert": [1., -40.], "units": "m s-1", "entry": "ua", "positive": ""},
          "T": {"convert": [1., 220], "units": "K", "entry": "ta", "positive": ""},

--- a/Test/test_cmor_half_levels_wrong_generic_level.py
+++ b/Test/test_cmor_half_levels_wrong_generic_level.py
@@ -1,8 +1,17 @@
 from __future__ import print_function
-import cdms2
 import cmor
 import numpy
 import os
+import sys
+
+try:
+    import cdms2
+    cdms2.setNetcdfShuffleFlag(0)
+    cdms2.setNetcdfDeflateFlag(0)
+    cdms2.setNetcdfDeflateLevelFlag(0)
+except BaseException:
+    print("This test code needs a recent cdms2 interface for i/0")
+    sys.exit()
 
 specs = {"CLOUD": {"convert": [2.0, 0.], "units": "%", "entry": "cl", "positive": ""},
          "U": {"convert": [1., -40.], "units": "m s-1", "entry": "ua", "positive": ""},

--- a/Test/test_cmor_half_levels_wrong_generic_level.py
+++ b/Test/test_cmor_half_levels_wrong_generic_level.py
@@ -4,15 +4,6 @@ import numpy
 import os
 import sys
 
-try:
-    import cdms2
-    cdms2.setNetcdfShuffleFlag(0)
-    cdms2.setNetcdfDeflateFlag(0)
-    cdms2.setNetcdfDeflateLevelFlag(0)
-except BaseException:
-    print("This test code needs a recent cdms2 interface for i/0")
-    sys.exit()
-
 specs = {"CLOUD": {"convert": [2.0, 0.], "units": "%", "entry": "cl", "positive": ""},
          "U": {"convert": [1., -40.], "units": "m s-1", "entry": "ua", "positive": ""},
          "T": {"convert": [1., 220], "units": "K", "entry": "ta", "positive": ""},

--- a/Test/test_cmor_python_zhalfo.py
+++ b/Test/test_cmor_python_zhalfo.py
@@ -31,7 +31,7 @@ def main():
 
     axis_ids = list()
     for axis in axes:
-        print 'doing:', axis
+        print('doing: {}'.format(axis))
         axis_id = cmor.axis(**axis)
         axis_ids.append(axis_id)
 

--- a/Test/test_python_CMIP6_CV_HISTORY.py
+++ b/Test/test_python_CMIP6_CV_HISTORY.py
@@ -19,6 +19,7 @@ import netCDF4
 import os
 import sys
 import tempfile
+import pkgutil
 import base_CMIP6_CV
 
 
@@ -60,7 +61,36 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         a = f.__dict__["history"]
         self.assertIn("set for CMIP6 unittest", a)
 
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
 
+        # -------------------------------------------
+        # Try to call cmor with a bad institution_ID
+        # -------------------------------------------
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+        cmor.load_table("CMIP6_Omon.json")
+
+        cmor.set_cur_dataset_attribute("history", "set for CMIP6 unittest")
+
+        # ------------------------------------------
+        # load Omon table and create masso variable
+        # ------------------------------------------
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2010',
+                        coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                        cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ivar = cmor.variable(table_entry="masso", axis_ids=[itime], units='kg')
+
+        data = numpy.random.random(5)
+        for i in range(0, 5):
+            cmor.write(ivar, data[i:i])
+        self.delete_files += [cmor.close(ivar, True)]
+        f = cdms2.open(cmor.get_final_filename(), "r")
+        a = f.getglobal("history")
+        self.assertIn("set for CMIP6 unittest", a)
+        
 
 if __name__ == '__main__':
     run()

--- a/Test/test_python_CMIP6_CV_HISTORY.py
+++ b/Test/test_python_CMIP6_CV_HISTORY.py
@@ -15,7 +15,7 @@
 import cmor
 import numpy
 import unittest
-import cdms2
+import netCDF4
 import os
 import sys
 import tempfile
@@ -55,8 +55,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         for i in range(0, 5):
             cmor.write(ivar, data[i:i])
         self.delete_files += [cmor.close(ivar, True)]
-        f = cdms2.open(cmor.get_final_filename(), "r")
-        a = f.getglobal("history")
+        f = netCDF4.Dataset(cmor.get_final_filename(), "r")
+        self.assertTrue("history" in f.__dict__)
+        a = f.__dict__["history"]
         self.assertIn("set for CMIP6 unittest", a)
 
 

--- a/Test/test_python_CMIP6_CV_externalvariables.py
+++ b/Test/test_python_CMIP6_CV_externalvariables.py
@@ -18,6 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
+import pkgutil
 import netCDF4
 import base_CMIP6_CV
 
@@ -29,7 +30,7 @@ def run():
 
 
 class TestCase(base_CMIP6_CV.BaseCVsTest):
-    def tstCMIP6(self):
+    def testCMIP6(self):
 
         nlat = 10
         dlat = 180. / nlat
@@ -83,6 +84,64 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         self.assertTrue("external_variables" in f.__dict__)
         a = f.__dict__["external_variables"]
         self.assertEqual("areacello volcello", a)
+        f.close()
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
+
+        nlat = 10
+        dlat = 180. / nlat
+        nlon = 20
+        dlon = 360. / nlon
+        nlev = 5
+        ntimes = 5
+
+        lats = numpy.arange(90 - dlat / 2., -90, -dlat)
+        blats = numpy.arange(90, -90 - dlat, -dlat)
+        lons = numpy.arange(0 + dlon / 2., 360., dlon)
+        blons = numpy.arange(0, 360. + dlon, dlon)
+
+        # -------------------------------------------
+        # Try to call cmor with a bad institution_ID
+        # -------------------------------------------
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+
+        # --------------------------------------------
+        # load Omon table and create masscello variable
+        # --------------------------------------------
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2010',
+                          coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                          cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ilat = cmor.axis(
+            table_entry='latitude',
+            coord_vals=lats,
+            cell_bounds=blats,
+            units='degrees_north')
+        ilon = cmor.axis(
+            table_entry='longitude',
+            coord_vals=lons,
+            cell_bounds=blons,
+            units='degrees_east')
+        ilev = cmor.axis(table_entry='depth_coord', length=5,
+                         cell_bounds=numpy.arange(0, 12000, 2000), coord_vals=numpy.arange(0, 10000, 2000), units="m")
+
+        ivar = cmor.variable(
+            table_entry="masscello", axis_ids=[
+                itime, ilev, ilat, ilon, ], units='kg/m2')
+
+        data = numpy.random.random((ntimes, nlev, nlat, nlon)) * 100.
+
+        cmor.write(ivar, data)
+        self.delete_files += [cmor.close(ivar, True)]
+        cmor.close()
+
+        f = cdms2.open(cmor.get_final_filename(), "r")
+        a = f.getglobal("external_variables")
+        self.assertEqual("areacello volcello", a)
+        f.close()
 
     def testCMIP6_ExternaVariablesError(self):
 
@@ -125,6 +184,51 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         f.close()
         f = netCDF4.Dataset(fname_ua, "r")
         self.assertTrue("external_variables" not in f.__dict__)
+        f.close()
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_ExternaVariablesError_CDMS2(self):
+        import cdms2
+
+        print("CMIP6 External Error")
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        error_flag = cmor.dataset_json('Test/CMOR_input_example.json')
+        table_id = cmor.load_table('CMIP6_6hrLev.json')
+        time = cmor.axis(table_entry='time1', units='days since 2000-01-01',
+                        coord_vals=numpy.array(range(1)),
+                        cell_bounds=numpy.array(range(2)))
+        latitude = cmor.axis(table_entry='latitude', units='degrees_north',
+                            coord_vals=numpy.array(range(5)),
+                            cell_bounds=numpy.array(range(6)))
+        longitude = cmor.axis(table_entry='longitude', units='degrees_east',
+                            coord_vals=numpy.array(range(5)),
+                            cell_bounds=numpy.array(range(6)))
+        plev3 = cmor.axis(table_entry='plev3', units='Pa',
+                        coord_vals=numpy.array([85000., 50000., 25000.]))
+        axis_ids = [longitude, latitude, plev3, time]
+        ua_var_id = cmor.variable(table_entry='ua', axis_ids=axis_ids,
+                                units='m s-1')
+        ta_var_id = cmor.variable(table_entry='ta', axis_ids=axis_ids,
+                                units='K')
+        data = numpy.random.random(75)
+        reshaped_data = data.reshape((5, 5, 3, 1))
+
+        # This doesn't:
+        cmor.write(ta_var_id, reshaped_data)
+        cmor.write(ua_var_id, reshaped_data)
+        fname_ta = cmor.close(ta_var_id, file_name=True)
+        fname_ua = cmor.close(ua_var_id, file_name=True)
+        self.delete_files += [cmor.close(ta_var_id, True)]
+        self.delete_files += [cmor.close(ua_var_id, True)]
+        cmor.close()
+
+        f = cdms2.open(fname_ta, "r")
+        a = f.getglobal("external_variables")
+        self.assertEqual("areacella", a)
+        f.close()
+        f = cdms2.open(fname_ua, "r")
+        a = f.getglobal("external_variables")
+        self.assertEqual(None, a)
         f.close()
 
 

--- a/Test/test_python_CMIP6_CV_externalvariables.py
+++ b/Test/test_python_CMIP6_CV_externalvariables.py
@@ -18,7 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
-import cdms2
+import netCDF4
 import base_CMIP6_CV
 
 # ==============================
@@ -79,8 +79,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         self.delete_files += [cmor.close(ivar, True)]
         cmor.close()
 
-        f = cdms2.open(cmor.get_final_filename(), "r")
-        a = f.getglobal("external_variables")
+        f = netCDF4.Dataset(cmor.get_final_filename(), "r")
+        self.assertTrue("external_variables" in f.__dict__)
+        a = f.__dict__["external_variables"]
         self.assertEqual("areacello volcello", a)
 
     def testCMIP6_ExternaVariablesError(self):
@@ -117,13 +118,13 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         self.delete_files += [cmor.close(ua_var_id, True)]
         cmor.close()
 
-        f = cdms2.open(fname_ta, "r")
-        a = f.getglobal("external_variables")
+        f = netCDF4.Dataset(fname_ta, "r")
+        self.assertTrue("external_variables" in f.__dict__)
+        a = f.__dict__["external_variables"]
         self.assertEqual("areacella", a)
         f.close()
-        f = cdms2.open(fname_ua, "r")
-        a = f.getglobal("external_variables")
-        self.assertEqual(None, a)
+        f = netCDF4.Dataset(fname_ua, "r")
+        self.assertTrue("external_variables" not in f.__dict__)
         f.close()
 
 

--- a/Test/test_python_CMIP6_CV_furtherinfourl.py
+++ b/Test/test_python_CMIP6_CV_furtherinfourl.py
@@ -18,6 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
+import pkgutil
 import netCDF4
 import base_CMIP6_CV
 
@@ -58,6 +59,40 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         f = netCDF4.Dataset(cmor.get_final_filename(), "r")
         self.assertTrue("further_info_url" in f.__dict__)
         a = f.__dict__["further_info_url"]
+        self.assertEqual(
+                "https://furtherinfo.es-doc.org/CMIP6.PCMDI.PCMDI-test-1-0.piControl-withism.none.r3i1p1f1",
+            a)
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
+        
+        # -------------------------------------------
+        # Try to call cmor with a bad institution_ID
+        # -------------------------------------------
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+
+        # ------------------------------------------
+        # load Omon table and create masso variable
+        # ------------------------------------------
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2000',
+                            coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                            cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ivar = cmor.variable(
+            table_entry="masso",
+            axis_ids=[itime],
+            units='kg')
+
+        data = numpy.random.random(5)
+        for i in range(0, 5):
+            cmor.write(ivar, data[i:i])
+        self.delete_files += [cmor.close(ivar, True)]
+        cmor.close()
+
+        f = cdms2.open(cmor.get_final_filename(), "r")
+        a = f.getglobal("further_info_url")
         self.assertEqual(
                 "https://furtherinfo.es-doc.org/CMIP6.PCMDI.PCMDI-test-1-0.piControl-withism.none.r3i1p1f1",
             a)

--- a/Test/test_python_CMIP6_CV_furtherinfourl.py
+++ b/Test/test_python_CMIP6_CV_furtherinfourl.py
@@ -18,7 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
-import cdms2
+import netCDF4
 import base_CMIP6_CV
 
 
@@ -55,8 +55,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         self.delete_files += [cmor.close(ivar, True)]
         cmor.close()
 
-        f = cdms2.open(cmor.get_final_filename(), "r")
-        a = f.getglobal("further_info_url")
+        f = netCDF4.Dataset(cmor.get_final_filename(), "r")
+        self.assertTrue("further_info_url" in f.__dict__)
+        a = f.__dict__["further_info_url"]
         self.assertEqual(
                 "https://furtherinfo.es-doc.org/CMIP6.PCMDI.PCMDI-test-1-0.piControl-withism.none.r3i1p1f1",
             a)

--- a/Test/test_python_CMIP6_CV_hierarchicalattr.py
+++ b/Test/test_python_CMIP6_CV_hierarchicalattr.py
@@ -18,6 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
+import pkgutil
 import netCDF4
 import base_CMIP6_CV
 
@@ -53,6 +54,36 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         cmor.close()
 
         f = netCDF4.Dataset(cmor.get_final_filename() , 'r')
+        self.assertEqual(f.coder, "Denis Nadeau")
+        self.assertEqual(f.hierarchical_attr_setting, "information")
+        self.assertEqual(f.creator, "PCMDI")
+        self.assertEqual(f.model, "Ocean Model")
+        self.assertEqual(f.country, "USA")
+        f.close()
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
+
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/common_user_input_hier.json")
+
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2010', coord_vals=numpy.array(
+            [0, 1, 2, 3, 4.]), cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ivar = cmor.variable(
+            table_entry="masso",
+            axis_ids=[itime],
+            units='kg')
+
+        data = numpy.random.random(5)
+        for i in range(0, 5):
+            # ,time_vals=numpy.array([i,]),time_bnds=numpy.array([i,i+1]))
+            cmor.write(ivar, data[i:i])
+        self.delete_files += [cmor.close(ivar, True)]
+        cmor.close()
+
+        f = cdms2.open(cmor.get_final_filename() , 'r')
         self.assertEqual(f.coder, "Denis Nadeau")
         self.assertEqual(f.hierarchical_attr_setting, "information")
         self.assertEqual(f.creator, "PCMDI")

--- a/Test/test_python_CMIP6_CV_hierarchicalattr.py
+++ b/Test/test_python_CMIP6_CV_hierarchicalattr.py
@@ -18,7 +18,7 @@ import unittest
 import os
 import sys
 import tempfile
-import cdms2
+import netCDF4
 import base_CMIP6_CV
 
 
@@ -52,7 +52,7 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         self.delete_files += [cmor.close(ivar, True)]
         cmor.close()
 
-        f = cdms2.open(cmor.get_final_filename() , 'r')
+        f = netCDF4.Dataset(cmor.get_final_filename() , 'r')
         self.assertEqual(f.coder, "Denis Nadeau")
         self.assertEqual(f.hierarchical_attr_setting, "information")
         self.assertEqual(f.creator, "PCMDI")

--- a/Test/test_python_CMIP6_CV_trackingNoprefix.py
+++ b/Test/test_python_CMIP6_CV_trackingNoprefix.py
@@ -18,6 +18,7 @@ import unittest
 import sys
 import os
 import tempfile
+import pkgutil
 import netCDF4
 import base_CMIP6_CV
 
@@ -58,6 +59,37 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         f = netCDF4.Dataset(cmor.get_final_filename(), "r")
         self.assertTrue("tracking_id" in f.__dict__)
         a = f.__dict__["tracking_id"].split('/')[0]
+        self.assertNotIn("hdl:21.14100/", a)
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
+
+        # -------------------------------------------
+        # Try to call cmor with a bad institution_ID
+        # -------------------------------------------
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+
+        # ------------------------------------------
+        # load Omon table and create masso variable
+        # ------------------------------------------
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2010',
+                            coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                            cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ivar = cmor.variable(
+            table_entry="masso",
+            axis_ids=[itime],
+            units='kg')
+
+        data = numpy.random.random(5)
+        for i in range(0, 5):
+            cmor.write(ivar, data[i:i])
+        self.delete_files += [cmor.close(ivar, True)]
+        filen = cmor.close()
+        f = cdms2.open(cmor.get_final_filename(), "r")
+        a = f.getglobal("tracking_id").split('/')[0]
         self.assertNotIn("hdl:21.14100/", a)
 
 

--- a/Test/test_python_CMIP6_CV_trackingNoprefix.py
+++ b/Test/test_python_CMIP6_CV_trackingNoprefix.py
@@ -18,7 +18,7 @@ import unittest
 import sys
 import os
 import tempfile
-import cdms2
+import netCDF4
 import base_CMIP6_CV
 
 
@@ -55,8 +55,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
             cmor.write(ivar, data[i:i])
         self.delete_files += [cmor.close(ivar, True)]
         filen = cmor.close()
-        f = cdms2.open(cmor.get_final_filename(), "r")
-        a = f.getglobal("tracking_id").split('/')[0]
+        f = netCDF4.Dataset(cmor.get_final_filename(), "r")
+        self.assertTrue("tracking_id" in f.__dict__)
+        a = f.__dict__["tracking_id"].split('/')[0]
         self.assertNotIn("hdl:21.14100/", a)
 
 

--- a/Test/test_python_CMIP6_CV_trackingprefix.py
+++ b/Test/test_python_CMIP6_CV_trackingprefix.py
@@ -18,6 +18,7 @@ import unittest
 import sys
 import os
 import tempfile
+import pkgutil
 import netCDF4
 import base_CMIP6_CV
 
@@ -56,6 +57,35 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         f = netCDF4.Dataset(cmor.get_final_filename(), "r")
         self.assertTrue("tracking_id" in f.__dict__)
         a = f.__dict__["tracking_id"].split('/')[0]
+        self.assertIn("hdl:21.14100", a)
+
+    @unittest.skipIf(pkgutil.find_loader("cdms2") is None, "cdms2 not installed")
+    def testCMIP6_CDMS2(self):
+        import cdms2
+
+        cmor.setup(inpath='Tables', netcdf_file_action=cmor.CMOR_REPLACE, logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+        cmor.set_cur_dataset_attribute("tracking_prefix", "hdl:21.14100")
+
+        # ------------------------------------------
+        # load Omon table and create masso variable
+        # ------------------------------------------
+        cmor.load_table("CMIP6_Omon.json")
+        itime = cmor.axis(table_entry="time", units='months since 2011',
+                            coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                            cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+        ivar = cmor.variable(
+            table_entry="masso",
+            axis_ids=[itime],
+            units='kg')
+
+        data = numpy.random.random(5)
+        for i in range(0, 5):
+            a = cmor.write(ivar, data[i:i])
+        self.delete_files += [cmor.close(ivar, True)]
+        cmor.close()
+        f = cdms2.open(cmor.get_final_filename(), "r")
+        a = f.getglobal("tracking_id").split('/')[0]
         self.assertIn("hdl:21.14100", a)
 
 if __name__ == '__main__':

--- a/Test/test_python_CMIP6_CV_trackingprefix.py
+++ b/Test/test_python_CMIP6_CV_trackingprefix.py
@@ -18,7 +18,7 @@ import unittest
 import sys
 import os
 import tempfile
-import cdms2
+import netCDF4
 import base_CMIP6_CV
 
 
@@ -53,8 +53,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
             a = cmor.write(ivar, data[i:i])
         self.delete_files += [cmor.close(ivar, True)]
         cmor.close()
-        f = cdms2.open(cmor.get_final_filename(), "r")
-        a = f.getglobal("tracking_id").split('/')[0]
+        f = netCDF4.Dataset(cmor.get_final_filename(), "r")
+        self.assertTrue("tracking_id" in f.__dict__)
+        a = f.__dict__["tracking_id"].split('/')[0]
         self.assertIn("hdl:21.14100", a)
 
 if __name__ == '__main__':

--- a/Test/test_python_CMIP6_CV_unicode.py
+++ b/Test/test_python_CMIP6_CV_unicode.py
@@ -18,7 +18,6 @@ import unittest
 import os
 import sys
 import tempfile
-import cdms2
 import base_CMIP6_CV
 
 

--- a/Test/test_python_direct_calls.py
+++ b/Test/test_python_direct_calls.py
@@ -37,17 +37,17 @@ myaxes[0] = cmor._cmor.axis(
     units,
     ntimes,
     Time,
-    'd',
+    b'd',
     bnds_time,
     2,
     "1 month")
 id = 'latitude'
 units = "degrees_north"
 interval = ""
-myaxes[1] = cmor._cmor.axis(id, units, lat, alats, 'd', bnds_lat, 2, interval)
+myaxes[1] = cmor._cmor.axis(id, units, lat, alats, b'd', bnds_lat, 2, interval)
 id = "longitude"
 units = "degrees_east"
-myaxes[2] = cmor._cmor.axis(id, units, lon, alons, 'd', bnds_lon, 2, interval)
+myaxes[2] = cmor._cmor.axis(id, units, lon, alons, b'd', bnds_lon, 2, interval)
 id = "plev19"
 units = "Pa"
 print(plevs.astype("d"))
@@ -56,7 +56,7 @@ myaxes[3] = cmor._cmor.axis(
     units,
     lev2,
     plevs.astype("d"),
-    'd',
+    b'd',
     None,
     0,
     interval)
@@ -67,14 +67,14 @@ myaxes[4] = cmor._cmor.axis(
     "1",
     5,
     zlevs,
-    'd',
+    b'd',
     zlev_bnds,
     1,
     interval)
 
 
 cmor.set_table(tables[0])
-myaxes[5] = cmor._cmor.axis("basin", "", 4, regions, 'c', None, 21, interval)
+myaxes[5] = cmor._cmor.axis("basin", "", 4, regions, b'c', None, 21, interval)
 id = 'time'
 units = 'months since 1980'
 myaxes[7] = cmor._cmor.axis(
@@ -82,14 +82,14 @@ myaxes[7] = cmor._cmor.axis(
     units,
     ntimes,
     Time,
-    'd',
+    b'd',
     bnds_time,
     2,
     "1 month")
 id = "latitude"
 units = "degrees_north"
 interval = ""
-myaxes[8] = cmor._cmor.axis(id, units, lat, alats, 'd', bnds_lat, 2, interval)
+myaxes[8] = cmor._cmor.axis(id, units, lat, alats, b'd', bnds_lat, 2, interval)
 
 cmor._cmor.set_table(tables[1])
 
@@ -107,7 +107,7 @@ myvars[0] = cmor._cmor.variable(
     units2d[0],
     3,
     myaxes,
-    'd',
+    b'd',
     None,
     dtmp2,
     positive2d[0],
@@ -120,7 +120,7 @@ myvars[1] = cmor._cmor.variable(
     units3d[2],
     4,
     myaxes2,
-    'd',
+    b'd',
     None,
     dtmp2,
     "down",
@@ -135,7 +135,7 @@ myvars[2] = cmor._cmor.variable(
     units3d[0],
     4,
     myaxes2,
-    'd',
+    b'd',
     None,
     dtmp2,
     "down",
@@ -148,20 +148,20 @@ print('vars 2')
 print('zfact', type(numpy.array(myaxes2[1])), type(myaxes2))
 
 myvars[3] = cmor._cmor.zfactor(
-    int(myaxes2[1]), "p0", "Pa", 0, None, 'd', p0, None)
+    int(myaxes2[1]), "p0", "Pa", 0, None, b'd', p0, None)
 print('zfact', myaxes2[1])
 myvars[3] = cmor._cmor.zfactor(
-    int(myaxes2[1]), "b", "", 1, myaxes2[1], 'd', b_coeff, b_coeff_bnds)
+    int(myaxes2[1]), "b", "", 1, myaxes2[1], b'd', b_coeff, b_coeff_bnds)
 print('zfact', myaxes2[1])
 myvars[3] = cmor._cmor.zfactor(
-    int(myaxes2[1]), "a", "", 1, myaxes2[1], 'd', a_coeff, a_coeff_bnds)
+    int(myaxes2[1]), "a", "", 1, myaxes2[1], b'd', a_coeff, a_coeff_bnds)
 #/*   printf("defining ap\n"); */
 #/*   for(i=0;i<5;i++) {a_coeff[i]*=1.e3;printf("sending acoef: %i, %lf\n",i,a_coeff[i]);} */
 #/*   for(i=0;i<6;i++) {a_coeff_bnds[i]*=1.e5;printf("sending acoef: %i, %lf\n",i,a_coeff_bnds[i]);} */
 #/*   ierr = cmor_zfactor(&myvars[3],myaxes2[1],"ap","hPa",1,&myaxes2[1],'d',&a_coeff,&a_coeff_bnds); */
 print('zfact before last')
 myvars[3] = cmor._cmor.zfactor(
-    int(myaxes2[1]), "ps", "hPa", 3, myaxes, 'd', None, None)
+    int(myaxes2[1]), "ps", "hPa", 3, myaxes, b'd', None, None)
 print('zfact last')
 
 #  /* ok here we decalre a variable for region axis testing */
@@ -175,7 +175,7 @@ myvars[4] = cmor._cmor.variable(
     "W",
     3,
     myaxes2,
-    'd',
+    b'd',
     None,
     dtmp2,
     positive2d[0],

--- a/Test/test_python_filename_time_range.py
+++ b/Test/test_python_filename_time_range.py
@@ -51,7 +51,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'hfds_Odec_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_2005-2015.nc')
+                         'r3i1p1f1_gn_2005-2015.nc')
 
     def test_yr(self):
         table = 'Tables/CMIP6_Eyr.json'
@@ -81,7 +81,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'baresoilFrac_Eyr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_2000-2001.nc')
+                         'r3i1p1f1_gn_2000-2001.nc')
 
     def test_mon(self):
         table = 'Tables/CMIP6_Amon.json'
@@ -111,7 +111,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ts_Amon_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001-200002.nc')
+                         'r3i1p1f1_gn_200001-200002.nc')
 
     def test_monclim(self):
         table = 'Tables/CMIP6_Oclim.json'
@@ -141,7 +141,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'difmxybo_Oclim_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001-200002-clim.nc')
+                         'r3i1p1f1_gn_200001-200002-clim.nc')
 
     def test_day(self):
         table = 'Tables/CMIP6_Eday.json'
@@ -171,7 +171,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ts_Eday_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_20000101-20000102.nc')
+                         'r3i1p1f1_gn_20000101-20000102.nc')
 
     def test_6hr(self):
         table = 'Tables/CMIP6_6hrLev.json'
@@ -201,7 +201,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ps_6hrLev_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001010300-200001010900.nc')
+                         'r3i1p1f1_gn_200001010300-200001010900.nc')
 
     def test_3hr(self):
         table = 'Tables/CMIP6_3hr.json'
@@ -231,24 +231,24 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ps_3hr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001010130-200001010430.nc')
+                         'r3i1p1f1_gn_200001010130-200001010430.nc')
 
     def test_1hr(self):
         table = 'Tables/CMIP6_E1hr.json'
         cmor.load_table(table)
         axes = [
             {'table_entry': 'time1',
-             'units': 'minutes since 2000-01-01 00:00:00',
-             'coord_vals': np.array([12.5, 37.5]),
-             'cell_bounds': [[0, 25], [25, 50]]},
+            'units': 'minutes since 2000-01-01 00:00:00',
+            'coord_vals': np.array([30, 90]),
+            'cell_bounds': [[0, 60], [60, 120]]},
             {'table_entry': 'latitude',
-             'units': 'degrees_north',
-             'coord_vals': [0],
-             'cell_bounds': [-1, 1]},
+            'units': 'degrees_north',
+            'coord_vals': [0],
+            'cell_bounds': [-1, 1]},
             {'table_entry': 'longitude',
-             'units': 'degrees_east',
-             'coord_vals': [90],
-             'cell_bounds': [89, 91]}
+            'units': 'degrees_east',
+            'coord_vals': [90],
+            'cell_bounds': [89, 91]}
         ]
 
         axis_ids = list()
@@ -261,7 +261,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'psl_E1hr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001010013-200001010038.nc')
+                         'r3i1p1f1_gn_200001010030-200001010130.nc')
 
     def test_1hrclimmon(self):
         table = 'Tables/CMIP6_E1hrClimMon.json'
@@ -291,7 +291,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'rlut_E1hrClimMon_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001010000-200001010050-clim.nc')
+                         'r3i1p1f1_gn_200001010000-200001010050-clim.nc')
 
     def test_subhr(self):
         table = 'Tables/CMIP6_Esubhr.json'
@@ -321,7 +321,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'pr_Esubhr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_20000101001230-20000101003730.nc')
+                         'r3i1p1f1_gn_20000101001230-20000101003730.nc')
 
     def test_day_rounds(self):
         table = 'Tables/CMIP6_Eday.json'
@@ -352,7 +352,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ts_Eday_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_19600102-19600103.nc')
+                         'r3i1p1f1_gn_19600102-19600103.nc')
 
     def test_hour_rounds_midnight(self):
         table = 'Tables/CMIP6_6hrLev.json'
@@ -382,7 +382,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'ps_6hrLev_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001020000-200001020600.nc')
+                         'r3i1p1f1_gn_200001020000-200001020600.nc')
 
     def test_hour_rounds_minutes(self):
         table = 'Tables/CMIP6_E1hr.json'
@@ -411,7 +411,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'psl_E1hr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001010013-200001010037.nc')
+                         'r3i1p1f1_gn_200001010013-200001010037.nc')
 
     def test_subhr_rounds_seconds(self):
         table = 'Tables/CMIP6_Esubhr.json'
@@ -440,7 +440,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'pr_Esubhr_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_20000101001230-20000101003731.nc')
+                         'r3i1p1f1_gn_20000101001230-20000101003731.nc')
 
     def test_monclim_rounding_start_time(self):
         table = 'Tables/CMIP6_Oclim.json'
@@ -470,7 +470,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'difmxybo_Oclim_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001-200002-clim.nc')
+                         'r3i1p1f1_gn_200001-200002-clim.nc')
 
     def test_monclim_rounding_end_time(self):
         """
@@ -505,7 +505,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'difmxybo_Oclim_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr_200001-200002-clim.nc')
+                         'r3i1p1f1_gn_200001-200002-clim.nc')
 
     def test_fx(self):
         table = 'Tables/CMIP6_fx.json'
@@ -531,7 +531,7 @@ class TestHasCurDatasetAttribute(unittest.TestCase):
 
         self.assertEqual(os.path.basename(self.path),
                          'orog_fx_PCMDI-test-1-0_piControl-withism_'
-                         'r11i1p1f1_gr.nc')
+                         'r3i1p1f1_gn.nc')
 
 #    def tearDown(self):
 #        if self.path:

--- a/Test/test_python_free_wrapping_issue.py
+++ b/Test/test_python_free_wrapping_issue.py
@@ -41,7 +41,7 @@ def save(opts, threeD=True):
         model_date = model_date.replace(day=1)
         min_tvals.append(model_date.toordinal() - 1)
         # max_bound is first day of next month
-        tyr = model_date.year + model_date.month / 12
+        tyr = model_date.year + int(model_date.month / 12)
         tmon = model_date.month % 12 + 1
         model_date = model_date.replace(year=tyr, month=tmon)
         max_tvals.append(model_date.toordinal() - 1)

--- a/Test/test_python_history.py
+++ b/Test/test_python_history.py
@@ -18,8 +18,16 @@ import unittest
 import sys
 import os
 import tempfile
-import cdms2
 import time
+
+try:
+    import cdms2
+    cdms2.setNetcdfShuffleFlag(0)
+    cdms2.setNetcdfDeflateFlag(0)
+    cdms2.setNetcdfDeflateLevelFlag(0)
+except BaseException:
+    print("This test code needs a recent cdms2 interface for i/0")
+    sys.exit()
 
 
 class TestCase(unittest.TestCase):
@@ -76,7 +84,7 @@ class TestCase(unittest.TestCase):
         os.dup2(self.newstdout, 1)
         os.dup2(self.newstderr, 2)
         version =time.strftime("%Y%m%d")
-        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Omon/masso/gr/v"+version+"/masso_Omon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_201001-201005.nc")
+        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Omon/masso/gn/v"+version+"/masso_Omon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_201001-201005.nc")
         history=f.history
         self.assertIn("CMOR mip_era is: CMIP6",history)
         self.assertIn("myMIP",history)

--- a/Test/test_python_joerg_3.py
+++ b/Test/test_python_joerg_3.py
@@ -150,5 +150,3 @@ for d in range(2):
     print('File1:', file1)
     print('File2:', file2)
     cmor.close()
-print(cmor.close(ivar1, True))
-cmor.close()

--- a/Test/test_python_joerg_tim2_clim_02.py
+++ b/Test/test_python_joerg_tim2_clim_02.py
@@ -38,7 +38,7 @@ def main():
         axis_ids.append(axis_id)
 
     for var, units, value in (('difvso', 'm2 s-1', 274.),):
-        values = numpy.ones(map(lambda x: len(x["coord_vals"]), axes)) * value
+        values = numpy.ones([len(x["coord_vals"]) for x in axes]) * value
         values = values.astype("f")
         varid = cmor.variable(var,
                               units,

--- a/Test/test_python_missing_values.py
+++ b/Test/test_python_missing_values.py
@@ -18,8 +18,16 @@ import unittest
 import sys
 import os
 import tempfile
-import cdms2
 import time
+
+try:
+    import cdms2
+    cdms2.setNetcdfShuffleFlag(0)
+    cdms2.setNetcdfDeflateFlag(0)
+    cdms2.setNetcdfDeflateLevelFlag(0)
+except BaseException:
+    print("This test code needs a recent cdms2 interface for i/0")
+    sys.exit()
 
 
 class TestCase(unittest.TestCase):
@@ -58,7 +66,7 @@ class TestCase(unittest.TestCase):
             raise
 
         version =time.strftime("%Y%m%d")
-        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Omon/massoint/gr/v"+version+"/massoint_Omon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_201001-201005.nc")
+        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Omon/massoint/gn/v"+version+"/massoint_Omon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_201001-201005.nc")
         var=f['massoint']
         self.assertEqual(var.missing_value[0], -999)
 
@@ -97,7 +105,7 @@ class TestCase(unittest.TestCase):
 
 
         version =time.strftime("%Y%m%d")
-        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Omon/massoint/gr/v"+version+"/massoint_Omon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_201001-201005.nc")
+        f=cdms2.open("CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Omon/massoint/gn/v"+version+"/massoint_Omon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_201001-201005.nc")
         var=f['massoint']
         self.assertEqual(var.missing_value[0], -999)
         self.assertTrue(var[0].mask)

--- a/Test/test_python_toomany_tables.py
+++ b/Test/test_python_toomany_tables.py
@@ -87,8 +87,8 @@ class TestCase(unittest.TestCase):
             pass
         os.dup2(newstdout, 1)
         os.dup2(newstderr, 2)
-        sys.stdout = os.fdopen(newstdout, 'w', 0)
-        sys.stderr = os.fdopen(newstderr, 'w', 0)
+        sys.stdout = os.fdopen(newstdout, 'wb', 0)
+        sys.stderr = os.fdopen(newstderr, 'wb', 0)
         f = open(tmpfile[1], 'r')
         lines = f.readlines()
         for line in lines:
@@ -98,9 +98,9 @@ class TestCase(unittest.TestCase):
         f.close()
         os.unlink(tmpfile[1])
 
-    def tearDown(self):
-        import shutil
-        shutil.rmtree("./CMIP6")
+    # def tearDown(self):
+    #     import shutil
+    #     shutil.rmtree("./CMIP6")
 
 
 if __name__ == '__main__':

--- a/Test/test_python_user_interface_00.py
+++ b/Test/test_python_user_interface_00.py
@@ -34,9 +34,9 @@ id = "time"
 units = "months since 1980"
 print('time bounds:', bnds_time)
 # ok we need to make the bounds 2D because the cmor module "undoes this"
-bnds_time = numpy.reshape(bnds_time, (bnds_time.shape[0] / 2, 2))
-bnds_lat = numpy.reshape(bnds_lat, (bnds_lat.shape[0] / 2, 2))
-bnds_lon = numpy.reshape(bnds_lon, (bnds_lon.shape[0] / 2, 2))
+bnds_time = numpy.reshape(bnds_time, (int(bnds_time.shape[0] / 2), 2))
+bnds_lat = numpy.reshape(bnds_lat, (int(bnds_lat.shape[0] / 2), 2))
+bnds_lon = numpy.reshape(bnds_lon, (int(bnds_lon.shape[0] / 2), 2))
 myaxes[0] = cmor.axis(
     id,
     coord_vals=Time,

--- a/Test/test_python_user_interface_03.py
+++ b/Test/test_python_user_interface_03.py
@@ -94,7 +94,7 @@ for var in ['tas', ]:
         cmor.write(var_id, df)
         cmor.close()
 #        fn = "CMIP6/CMIP/CSIRO-BOM/NICAM/piControl/r1i1p1f1/Amon/%s/gn/v%s/%s_Amon_piControl_NICAM_r1i1p1f1_gn_197901-199605.nc" %(var,today,var)
-        fn = "/software/cmor3/cmor/CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r11i1p1f1/Amon/%s/gr/v%s/%s_Amon_PCMDI-test-1-0_piControl-withism_r11i1p1f1_gr_197901-199605.nc" % (
+        fn = "CMIP6/CMIP6/ISMIP6/PCMDI/PCMDI-test-1-0/piControl-withism/r3i1p1f1/Amon/%s/gn/v%s/%s_Amon_PCMDI-test-1-0_piControl-withism_r3i1p1f1_gn_197901-199605.nc" % (
             var, today, var)
         f = cdms2.open(fn)
         s = f(var)

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -26,10 +26,10 @@ requirements:
     - six
     - json-c
     - hdf5
-    - libnetcdf 4.6.2
+    - libnetcdf
+    - netcdf4
     - numpy
     - setuptools
-    - cdms2
   run:
     - python {{ python }}
     - libuuid
@@ -39,7 +39,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('hdf5') }}
     - {{ pin_compatible('libnetcdf') }}
-    - cdms2
+    - {{ pin_compatible('netcdf4') }}
 
 about:
     home:  http://gitub.com/PCMDI


### PR DESCRIPTION
Resolves #490 

This PR replaces the use of cdms2 in PrePARE and some of the Python tests with netCDF4.

Note: The MacOS CircleCI checks failed due to an error when creating the conda environment.

```
MD5MismatchError: Conda detected a mismatch between the expected content and downloaded content
for url 'https://repo.anaconda.com/pkgs/main/osx-64/libcxx-4.0.1-h579ed51_0.tar.bz2'.
  download saved to: /Users/distiller/project/workspace/test_macos_cmor/miniconda/pkgs/libcxx-4.0.1-h579ed51_0.tar.bz2
  expected md5 sum: 28471619a3a79da80d9b5747f1ec0221
  actual md5 sum: 291e61684d014641092020bdb1acb096
```

However, the changes that triggered the failed tests (https://github.com/PCMDI/cmor/commit/9f56aa6bf71c22e54315239c2e2f705d28cafa6a) didn't change the CircleCI configuration script.  The previous commit (https://github.com/PCMDI/cmor/commit/8ee711286de435522aaa5933ac848f1095389e91) that did change the CircleCI and Travis scripts was passing tests.
