### PR TITLE
Throw exception if not enough data is passed to cmor.write in Python

### DIFF
--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -774,8 +774,15 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
     # Check if there is enough data for the number of times passed
     if ntimes_passed < 0:
         raise Exception("ntimes_passed must be a positive integer")
-    elif ntimes_passed > osh[0]:
-        raise Exception("ntimes_passed must be less than or equal to the number of times in data")
+
+    expected_size = ntimes_passed
+    for d in goodshape:
+        expected_size *= d
+    passed_size = 1
+    for d in sh:
+        passed_size *= d
+    if expected_size > passed_size:
+        raise Exception("not enough data is being passed for the number of times passed")
 
     data = numpy.ascontiguousarray(numpy.ravel(data))
 

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -783,7 +783,7 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
     for d in goodshape:
         expected_size *= d
     passed_size = 1
-    for d in sh:
+    for d in osh:
         passed_size *= d
     if expected_size > passed_size:
         raise Exception("not enough data is being passed for the number of times passed")

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -770,6 +770,13 @@ def write(var_id, data, ntimes_passed=None, file_suffix="",
                 warnings.warn(msg)
         j += 1
 
+    
+    # Check if there is enough data for the number of times passed
+    if ntimes_passed < 0:
+        raise Exception("ntimes_passed must be a positive integer")
+    elif ntimes_passed > osh[0]:
+        raise Exception("ntimes_passed must be less than or equal to the number of times in data")
+
     data = numpy.ascontiguousarray(numpy.ravel(data))
 
     if time_bnds is not None: 

--- a/Makefile.in
+++ b/Makefile.in
@@ -219,6 +219,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_half_levels_with_bounds.py make test_a_python
 	env TEST_NAME=Test/test_cmor_half_levels_wrong_generic_level.py make test_a_python
 	env TEST_NAME=Test/test_cmor_double_singleton.py make test_a_python
+	env TEST_NAME=Test/test_cmor_python_not_enough_data.py make test_a_python
 test_python_2gb:
 	env TEST_NAME=Test/test_python_2Gb_file.py make test_a_python
 	env TEST_NAME=Test/test_python_2Gb_slice.py make test_a_python

--- a/Test/test_cmor_python_not_enough_data.py
+++ b/Test/test_cmor_python_not_enough_data.py
@@ -4,10 +4,9 @@ import unittest
 import sys
 import os
 import tempfile
-import base_CMIP6_CV
 
 
-class TestCase(base_CMIP6_CV.BaseCVsTest):
+class TestCase(unittest.TestCase):
 
     # This test demonstrates an exception that gets thrown when
     # ntimes_passed is greater than the number of times passed in data

--- a/Test/test_python_CMIP6_CV_not_enough_data.py
+++ b/Test/test_python_CMIP6_CV_not_enough_data.py
@@ -1,0 +1,67 @@
+import cmor
+import numpy
+import unittest
+import sys
+import os
+import tempfile
+import base_CMIP6_CV
+
+
+class TestCase(base_CMIP6_CV.BaseCVsTest):
+
+    # This test demonstrates an exception that gets thrown when
+    # ntimes_passed is greater than the number of times passed in data
+    def testNotEnoughData(self):
+
+        cmor.setup(inpath='Tables',
+                netcdf_file_action=cmor.CMOR_REPLACE)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+
+        table = 'CMIP6_Omon.json'
+        cmor.load_table(table)
+        axes = [{'table_entry': 'time',
+                'units': 'days since 1850-01-01 00:00:00',
+                'coord_vals': [15.5, 45, ],
+                'cell_bounds':[[0, 31], [31, 62]]
+                },
+                {'table_entry': 'depth_coord_half',
+                'units': 'm',
+                'coord_vals': [5000., 3000., 2000., 1000.],
+                'cell_bounds': [5000., 3000., 2000., 1000., 0]},
+                {'table_entry': 'latitude',
+                'units': 'degrees_north',
+                'coord_vals': [0],
+                'cell_bounds': [-1, 1]},
+                {'table_entry': 'longitude',
+                'units': 'degrees_east',
+                'coord_vals': [90],
+                'cell_bounds': [89, 91]},
+                ]
+
+        axis_ids = list()
+        for axis in axes:
+            axis_id = cmor.axis(**axis)
+            axis_ids.append(axis_id)
+
+        for var, units, value in (('zhalfo', 'm', 274.),):
+            values = numpy.ones([len(x['coord_vals']) for x in axes]) * value
+            values = values.astype("f")
+            varid = cmor.variable(var,
+                                units,
+                                axis_ids,
+                                history='variable history',
+                                missing_value=-99
+                                )
+            try:
+                cmor.write(varid, values, ntimes_passed=3)
+            except Exception as inst:
+                self.assertEqual(repr(inst), "Exception('ntimes_passed must "
+                                             "be less than or equal to the "
+                                             "number of times in data')")
+            else:
+                raise Exception("cmor.write did not throw exception")
+
+        cmor.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Test/test_python_CMIP6_CV_not_enough_data.py
+++ b/Test/test_python_CMIP6_CV_not_enough_data.py
@@ -55,9 +55,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
             try:
                 cmor.write(varid, values, ntimes_passed=3)
             except Exception as inst:
-                self.assertEqual(repr(inst), "Exception('ntimes_passed must "
-                                             "be less than or equal to the "
-                                             "number of times in data')")
+                self.assertEqual(str(inst), "ntimes_passed must "
+                                            "be less than or equal to the "
+                                            "number of times in data")
             else:
                 raise Exception("cmor.write did not throw exception")
 

--- a/Test/test_python_CMIP6_CV_not_enough_data.py
+++ b/Test/test_python_CMIP6_CV_not_enough_data.py
@@ -55,11 +55,10 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
             try:
                 cmor.write(varid, values, ntimes_passed=3)
             except Exception as inst:
-                self.assertEqual(str(inst), "ntimes_passed must "
-                                            "be less than or equal to the "
-                                            "number of times in data")
+                self.assertEqual(str(inst), "not enough data is being passed "
+                                            "for the number of times passed")
             else:
-                raise Exception("cmor.write did not throw exception")
+                raise Exception("cmor.write did not throw expected exception")
 
         cmor.close()
 


### PR DESCRIPTION
Resolves #485

This change checks the amount of data being passed to cmor.write in Python if it is the expected amount for the amount of time passed (either by setting ntimes_passed or passing time values).  It will throw an exception if the amount is lower than expected (or if ntimes_passed is negative).

I also added a test to see if the exception is being thrown.

As for Fortran, it looks like it already handles this issue.
https://github.com/PCMDI/cmor/blob/8a48023d6456b596df5f0a1a9440bc3fe4d2634c/Src/cmor_fortran_interface.f90#L1032-L1037