### PR TITLE
Replace json-c macros TRUE and FALSE with 1 and 0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -109,7 +109,7 @@ int CMOR_CREATE_SUBDIRECTORIES = 1;
 char cmor_input_path[CMOR_MAX_STRING];
 char cmor_traceback_info[CMOR_MAX_STRING];
 
-int bAppendMode = FALSE;
+int bAppendMode = 0;
 
 volatile sig_atomic_t stop = 0;
 
@@ -2604,7 +2604,7 @@ int cmor_validateFilename(char *outname, char *file_suffix, int var_id)
             ierr = nc_create(outname, NC_CLOBBER | cmode, &ncid);
 
         } else {                /*ok it was there already */
-            bAppendMode = TRUE;
+            bAppendMode = 1;
             ierr = fclose(fperr);
             fperr = NULL;
             copyfile(outname, file_suffix);

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -1405,7 +1405,7 @@ int cmor_CV_checkExperiment(cmor_CV_def_t * CV)
     nObjects = CV_experiment->nbObjects;
     // Parse all experiment attributes
     for (i = 0; i < nObjects; i++) {
-        bWarning = FALSE;
+        bWarning = 0;
         CV_experiment_attr = &CV_experiment->oValue[i];
         rc = cmor_has_cur_dataset_attribute(CV_experiment_attr->key);
         strcpy(szExpValue, CV_experiment_attr->szValue);
@@ -1435,7 +1435,7 @@ int cmor_CV_checkExperiment(cmor_CV_def_t * CV)
                 if (j == CV_experiment_attr->anElements) {
                     if (CV_experiment_attr->anElements == 1) {
                         strcpy(szExpValue, CV_experiment_attr->aszValue[0]);
-                        bWarning = TRUE;
+                        bWarning = 1;
                     } else {
                         snprintf(msg, CMOR_MAX_STRING,
                                  "Your input attribute \"%s\" with value \n! \"%s\" "
@@ -1457,12 +1457,12 @@ int cmor_CV_checkExperiment(cmor_CV_def_t * CV)
                     if (strncmp(CV_experiment_attr->szValue, szValue,
                     CMOR_MAX_STRING) != 0) {
                         strcpy(szExpValue, CV_experiment_attr->szValue);
-                        bWarning = TRUE;
+                        bWarning = 1;
                     }
                 }
             }
         }
-        if (bWarning == TRUE) {
+        if (bWarning == 1) {
             snprintf(msg, CMOR_MAX_STRING,
                      "Your input attribute \"%s\" with value \n! \"%s\" "
                      "will be replaced with "
@@ -2153,7 +2153,7 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
     int i;
     int rc;
     char msg[CMOR_MAX_STRING];
-    int bCriticalError = FALSE;
+    int bCriticalError = 0;
     int ierr = 0;
     cmor_add_traceback("_CV_checkGblAttributes");
     required_attrs = cmor_CV_rootsearch(CV, CV_KEY_REQUIRED_GBL_ATTRS);
@@ -2168,12 +2168,12 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
                          "Please set attribute: \"%s\" in your input file.",
                          required_attrs->aszValue[i]);
                 cmor_handle_error(msg, CMOR_NORMAL);
-                bCriticalError = TRUE;
+                bCriticalError = 1;
                 ierr += -1;
             }
             rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
             if (rc != 0) {
-                bCriticalError = TRUE;
+                bCriticalError = 1;
                 ierr += -1;
             }
         }


### PR DESCRIPTION
Resolves #508 
@wachsylon pointed out that the latest version of json-c no longer uses `TRUE` and `FALSE` macros and just use the values 1 and 0, which were what the macros represented.