### PR TITLE
Use the latest version of Miniconda 2 in Travis

### DIFF
--- a/scripts/conda_upload.sh
+++ b/scripts/conda_upload.sh
@@ -8,7 +8,7 @@ if [ `uname` == "Linux" ]; then
     yum install -y wget git gcc
     if [ $CMOR_PYTHON_VERSION == '2.7' ]; then 
         echo "Using Python $CMOR_PYTHON_VERSION"
-        wget --no-check https://repo.continuum.io/miniconda/Miniconda2-4.3.30-Linux-x86_64.sh -O miniconda2.sh
+        wget --no-check https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda2.sh
         bash miniconda2.sh -b -p ${HOME}/miniconda
     elif [ $CMOR_PYTHON_VERSION == '3.6' ] || [ $CMOR_PYTHON_VERSION == '3.7' ]; then 
         echo "Using Python $CMOR_PYTHON_VERSION"


### PR DESCRIPTION
@doutriaux1 
The current Travis builds are working for Python 3.6 and 3.7 but not for 2.7.  The Python 2.7 build in Travis has a bunch of these errors when installing  conda-build
```
CondaMultiError: InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/traitlets-4.3.2-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748270522976)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/decorator-4.4.0-py27_1.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273217232)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/liblief-0.9.0-h1532aa0_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273217232)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/ipython_genutils-0.2.0-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748270522976)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/scandir-1.10.0-py27h7b6447c_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273217232)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/patchelf-0.9-hf484d3e_2.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264581744)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/pkginfo-1.5.0.1-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273217232)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/ca-certificates-2019.5.15-0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264581744)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/pyyaml-5.1.1-py27h7b6447c_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273723344)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/functools32-3.2.3.2-py27_1.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264581744)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/jsonschema-2.6.0-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748273723344)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/py-lief-0.9.0-py27h1532aa0_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264581744)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/markupsafe-1.1.1-py27h7b6447c_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264581744)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/psutil-5.6.3-py27h7b6447c_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748264582816)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/jinja2-2.10.1-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272863808)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/certifi-2019.6.16-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272863808)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/python-dateutil-2.8.0-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272864864)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/nbformat-4.4.0-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272363424)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/beautifulsoup4-4.7.1-py27_1.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272363424)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/contextlib2-0.5.5-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272351952)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/clyent-1.2.2-py27_1.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272353984)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/anaconda-client-1.7.2-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272353984)',)
InvalidArchiveError(u'Error with archive /root/miniconda/pkgs/soupsieve-1.8-py27_0.conda.  You probably need to delete and re-download or re-create this file.  Message from libarchive was:\n\nChild process exited with status 127 (errno=-1, retcode=-30, archive_p=94748272353984)',)

cmor/meta.yaml.in 2019.07.11.master 2019.07.11.2019.07.11.16.20.{{ GIT_DESCRIBE_HASH }}
Building now

CommandNotFoundError: To use 'conda build', install conda-build.
```

The conda_upload.sh script was using Miniconda 2 version 4.3.30.
https://github.com/PCMDI/cmor/blob/7aee13f5f0c3787594820f204f1a920640abce7a/scripts/conda_upload.sh#L11
This PR will make Travis use the latest version of Miniconda 2, which is also used in the CircleCI build.

I'm not sure if this is the source of the error but I think it is worth changing.