### PR TITLE
fixed user output in cmor_grids with resp. to false_northing

### DIFF
--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -222,7 +222,7 @@ int cmor_set_grid_attribute(int gid, char *name, double *value, char *units)
         }
         if (j == -1) {
             snprintf(ctmp, CMOR_MAX_STRING,
-                     "grid mapping attribute: 'false easting' must be set in conjunction with a 'projection_x_coordinate' axis, I could not find such an axis on your grid, we will not set this attribute");
+                     "grid mapping attribute: 'false northing' must be set in conjunction with a 'projection_y_coordinate' axis, I could not find such an axis on your grid, we will not set this attribute");
             cmor_handle_error(ctmp, CMOR_NORMAL);
             cmor_pop_traceback();
             return (1);


### PR DESCRIPTION
If the grid mapping variable has the attribute `false_northing` then a variable with standard name `projection_y_coordinate` has to exist. A check to verify this is performed. The corresponding error message for "`false_northing` is set but `projection_x_coordinate` does not exist" contais two copy-&-paste errors. See #547 for details. Fixes #547.