### PR TITLE
Upgrade CircleCI MacOS tests to Xcode 11.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ aliases:
 jobs:
   macos_cmor_py27:
     macos:
-      xcode: "9.2.0"
+      xcode: "11.1.0"
     environment:
       PYTHON_VERSION: "2.7"
       WORKDIR: "workspace/test_macos_cmor"
@@ -116,7 +116,7 @@ jobs:
 
   macos_cmor_py36:
     macos:
-      xcode: "9.2.0"
+      xcode: "11.1.0"
     environment:
       PYTHON_VERSION: "3.6"
       WORKDIR: "workspace/test_macos_cmor"
@@ -136,7 +136,7 @@ jobs:
 
   macos_cmor_py37:
     macos:
-      xcode: "9.2.0"
+      xcode: "11.1.0"
     environment:
       PYTHON_VERSION: "3.7"
       WORKDIR: "workspace/test_macos_cmor"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,9 +218,9 @@ workflows:
   version: 2
   nightly:
     jobs:
-      - macos_cmor_py27
+      # - macos_cmor_py27
       - macos_cmor_py36
-      - macos_cmor_py37
-      - linux_cmor_py27
-      - linux_cmor_py36
-      - linux_cmor_py37
+      # - macos_cmor_py37
+      # - linux_cmor_py27
+      # - linux_cmor_py36
+      # - linux_cmor_py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,9 +218,9 @@ workflows:
   version: 2
   nightly:
     jobs:
-      # - macos_cmor_py27
+      - macos_cmor_py27
       - macos_cmor_py36
-      # - macos_cmor_py37
-      # - linux_cmor_py27
-      # - linux_cmor_py36
-      # - linux_cmor_py37
+      - macos_cmor_py37
+      - linux_cmor_py27
+      - linux_cmor_py36
+      - linux_cmor_py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/recipes/cmor/build.sh
+++ b/recipes/cmor/build.sh
@@ -1,4 +1,4 @@
-export CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC ${CFLAGS}"
+export CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
 export CXXLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"
@@ -13,8 +13,6 @@ fi
 if [[ `uname` == "Linux" ]]; then
     export LDSHARED_FLAGS="-shared -pthread"
 else
-    # For OSX builds, reset the include and linker root path for clang
-    export CFLAGS="-Wl,-syslibroot / -isysroot / ${CFLAGS}"
     export LDSHARED_FLAGS="-bundle -undefined dynamic_lookup"
 fi
 

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -26,7 +26,7 @@ requirements:
     - six
     - json-c
     - hdf5
-    - libnetcdf
+    - libnetcdf 4.6.2
     - netcdf4
     - numpy
     - setuptools

--- a/setup.py.in
+++ b/setup.py.in
@@ -47,10 +47,6 @@ for p in include_dirs:
       ld.append(p)
 include_dirs=ld
 
-# For OSX builds, reset the include and linker root path for clang
-if sys.platform == "darwin":
-  os.environ["CFLAGS"]="-Wl,-syslibroot / -isysroot /"
-
 print('Setting up python module with:')
 print('libraries:',libraries)
 print('libdir:',library_dirs)


### PR DESCRIPTION
Fixes #555 

Upgrade Xcode from 9.2.0 to 11.1.0.

Additionally, use libnetcdf 4.6.2 to maintain compatibility with cdms2.