### PR TITLE
Pin openblas 0.3.6 and numpy >=1.14.6 in meta.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-      #  if [[ $CIRCLE_BRANCH != 'master' ]]; then
-      #     exit 0
-      #  fi
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+          exit 0
+       fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
        conda install conda-build anaconda-client
        conda config --set anaconda_upload no
@@ -88,10 +88,10 @@ aliases:
        export PKG_NAME=cmor
        export USER=pcmdi
        export VERSION=3.5.0
-       export LABEL=mauzey1
+       export LABEL=nightly
        python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
-       # anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
-          exit 0
-       fi
+      #  if [[ $CIRCLE_BRANCH != 'master' ]]; then
+      #     exit 0
+      #  fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
        conda install conda-build anaconda-client
        conda config --set anaconda_upload no
@@ -88,10 +88,10 @@ aliases:
        export PKG_NAME=cmor
        export USER=pcmdi
        export VERSION=3.5.0
-       export LABEL=nightly
+       export LABEL=mauzey1
        python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
-       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       # anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 
 jobs:

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -26,10 +26,10 @@ requirements:
     - six
     - json-c
     - hdf5
-    - openblas
+    - openblas 0.3.6
     - libnetcdf
     - netcdf4
-    - numpy
+    - numpy >=1.14.6
     - setuptools
   run:
     - python {{ python }}

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -37,7 +37,7 @@ requirements:
     - udunits2
     - six
     - json-c
-    - {{ pin_compatible('openblas') }}
+    - openblas 0.3.6
     - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('hdf5') }}
     - {{ pin_compatible('libnetcdf') }}


### PR DESCRIPTION
The nightly builds for OSX were trying to use an older version of numpy that was not compatible with the other packages.  This change will pin numpy versions 1.14.6 and greater to the nightly build.

It will also pin openblas 0.3.6 for compatibility with cdms2 from conda-forge.