### PR TITLE
Pin libnetcdf 4.6.2 and numpy >= 1.14.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas=0.3.6 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor
@@ -57,7 +57,7 @@ aliases:
        export UVCDAT_ANONYMOUS_LOG=False
        # run tests again but with cdms2 installed
        set +e
-       conda install -q -n py$PYTHON_VERSION -c conda-forge cdms2
+       conda install -q -n py$PYTHON_VERSION -c cdat/label/nighlty -c conda-forge cdms2
        source activate py$PYTHON_VERSION
        set -e
        make test
@@ -77,9 +77,9 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
-          exit 0
-       fi
+      #  if [[ $CIRCLE_BRANCH != 'master' ]]; then
+      #     exit 0
+      #  fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
        conda install conda-build anaconda-client
        conda config --set anaconda_upload no
@@ -91,7 +91,7 @@ aliases:
        export LABEL=nightly
        python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
-       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+      #  anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 
 jobs:
@@ -219,9 +219,9 @@ workflows:
   version: 2
   nightly:
     jobs:
-      - macos_cmor_py27
+      # - macos_cmor_py27
       - macos_cmor_py36
-      - macos_cmor_py37
-      - linux_cmor_py27
+      # - macos_cmor_py37
+      # - linux_cmor_py27
       - linux_cmor_py36
-      - linux_cmor_py37
+      # - linux_cmor_py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,8 @@ aliases:
        export USER=pcmdi
        export VERSION=3.5.0
        export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION
-       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION -b $CIRCLE_BRANCH
+       python ./prep_for_build.py -l $VERSION -b $CIRCLE_BRANCH
+       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
       #  anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
        export UVCDAT_ANONYMOUS_LOG=False
        # run tests again but with cdms2 installed
        set +e
-       conda install -q -n py$PYTHON_VERSION -c cdat/label/nighlty -c conda-forge cdms2
+       conda install -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge cdms2
        source activate py$PYTHON_VERSION
        set -e
        make test
@@ -90,7 +90,7 @@ aliases:
        export VERSION=3.5.0
        export LABEL=nightly
        python ./prep_for_build.py -l $VERSION
-       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
+       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION -b $CIRCLE_BRANCH
       #  anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf==4.6.2 netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-      #  if [[ $CIRCLE_BRANCH != 'master' ]]; then
-      #     exit 0
-      #  fi
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+          exit 0
+       fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
        conda install conda-build anaconda-client
        conda config --set anaconda_upload no
@@ -89,9 +89,9 @@ aliases:
        export USER=pcmdi
        export VERSION=3.5.0
        export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION -b $CIRCLE_BRANCH
+       python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
-      #  anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
 
 jobs:
@@ -219,9 +219,9 @@ workflows:
   version: 2
   nightly:
     jobs:
-      # - macos_cmor_py27
+      - macos_cmor_py27
       - macos_cmor_py36
-      # - macos_cmor_py37
-      # - linux_cmor_py27
+      - macos_cmor_py37
+      - linux_cmor_py27
       - linux_cmor_py36
-      # - linux_cmor_py37
+      - linux_cmor_py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
 script:
   - make test
-  - conda install -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nighlty -c conda-forge cdms2
+  - conda install -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge cdms2
   - make test
   - export PYTHONPATH=Test/:$PYTHONPATH
   - python run_tests.py -v2 -n1 -H Test/test_python_CMIP6_CV*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas=0.3.6 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")
@@ -37,7 +37,7 @@ install:
 
 script:
   - make test
-  - conda install -q -n py${CMOR_PYTHON_VERSION} -c conda-forge cdms2
+  - conda install -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nighlty -c conda-forge cdms2
   - make test
   - export PYTHONPATH=Test/:$PYTHONPATH
   - python run_tests.py -v2 -n1 -H Test/test_python_CMIP6_CV*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas libnetcdf==4.6.2 netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -29,7 +29,7 @@ requirements:
     - openblas
     - libnetcdf 4.6.2
     - netcdf4
-    - numpy >= 1.14.6
+    - numpy >=1.14.6
     - setuptools
   run:
     - python {{ python }}
@@ -37,7 +37,7 @@ requirements:
     - udunits2
     - six
     - json-c
-    - numpy >= 1.14.6
+    - numpy >=1.14.6
     - libnetcdf 4.6.2
     - {{ pin_compatible('openblas') }}
     - {{ pin_compatible('hdf5') }}

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -29,7 +29,7 @@ requirements:
     - openblas
     - libnetcdf 4.6.2
     - netcdf4
-    - numpy
+    - numpy >= 1.14.6
     - setuptools
   run:
     - python {{ python }}
@@ -37,9 +37,9 @@ requirements:
     - udunits2
     - six
     - json-c
+    - numpy >= 1.14.6
     - libnetcdf 4.6.2
     - {{ pin_compatible('openblas') }}
-    - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('hdf5') }}
     - {{ pin_compatible('netcdf4') }}
 

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -27,7 +27,7 @@ requirements:
     - json-c
     - hdf5
     - openblas
-    - libnetcdf
+    - libnetcdf 4.6.2
     - netcdf4
     - numpy
     - setuptools
@@ -37,10 +37,10 @@ requirements:
     - udunits2
     - six
     - json-c
+    - libnetcdf 4.6.2
     - {{ pin_compatible('openblas') }}
     - {{ pin_compatible('numpy') }}
     - {{ pin_compatible('hdf5') }}
-    - {{ pin_compatible('libnetcdf') }}
     - {{ pin_compatible('netcdf4') }}
 
 about:


### PR DESCRIPTION
Closes #564 

The OSX builds in CircleCI have been downloading numpy 1.11, which is outdated and causing errors in the build.  The PR will pin numpy version 1.14.6 and greater.

This PR will also pin libnetcdf 4.6.2 so that we can use the nightly CDMS2 builds again.