### PR TITLE
Make PrePARE give an error if the activity_id is wrong.

### DIFF
--- a/Test/CMOR_input_example.json
+++ b/Test/CMOR_input_example.json
@@ -15,8 +15,8 @@
     "#note":                  "Text stored in attribute variant_info (recommended, not required description of run variant)",
     "run_variant":            "3rd realization",
  
-    "parent_experiment_id":   "historical",
-    "parent_activity_id":     "CMIP",
+    "parent_experiment_id":   "no parent",
+    "parent_activity_id":     "no parent",
     "parent_source_id":       "PCMDI-test-1-0",
     "parent_variant_label":   "r3i1p1f1",
  

--- a/Test/common_user_inputNOBOUNDS.json
+++ b/Test/common_user_inputNOBOUNDS.json
@@ -47,8 +47,8 @@
 
            "institution_id":         "PCMDI",
 
-           "parent_activity_id":     "CMIP",
-           "parent_experiment_id":   "histALL",
+           "parent_activity_id":     "no parent",
+           "parent_experiment_id":   "no parent",
            "parent_source_id":       "GFDL-CM2-1",
            "parent_variant_label":   "r1i1p1f3",
 

--- a/Test/common_user_input_NOID.json
+++ b/Test/common_user_input_NOID.json
@@ -46,8 +46,8 @@
            "nominal_resolution":     "5 km",
 
 
-           "parent_activity_id":     "CMIP",
-           "parent_experiment_id":   "histALL",
+           "parent_activity_id":     "no parent",
+           "parent_experiment_id":   "no parent",
            "parent_source_id":       "GFDL-CM2-1",
            "parent_variant_label":   "r1i1p1f3",
 

--- a/Test/common_user_input_hier.json
+++ b/Test/common_user_input_hier.json
@@ -48,8 +48,8 @@
 
            "institution_id":         "PCMDI",
 
-           "parent_activity_id":     "CMIP",
-           "parent_experiment_id":   "histALL",
+           "parent_activity_id":     "no parent",
+           "parent_experiment_id":   "no parent",
            "parent_source_id":       "GFDL-CM2-1",
            "parent_variant_label":   "r1i1p1f3",
 

--- a/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
+++ b/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
@@ -4,7 +4,7 @@
 
            "tracking_prefix":        "hdl:21.14100",
            "#activity_id":           "Specify an activity PMIP, GeoMIP, (must start with CMIP6-)",
-           "activity_id":            "ISMIP6",
+           "activity_id":            "RFMIP",
 
            "#output":                "Output Path where files are written",
            "outpath":                "CMIP6",
@@ -70,9 +70,9 @@
            "branch_time":             "1",
 
 
-           "parent_activity_id": "no parent",
-           "parent_experiment_id": "no parent",
-           "parent_source_id":   "GFDL-CM2-1",
+           "parent_activity_id": "CMIP",
+           "parent_experiment_id": "piControl",
+           "parent_source_id":   "PCMDI-test-1-0",
            "parent_variant_label":  "r1i1p1f3",
 
            "branch_method":         "standard",

--- a/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
+++ b/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
@@ -46,7 +46,6 @@
            "comment":                "Equilibrium reached after 30-year spin-up ",
 
            "#references":            "",
-           "references":             "Model described by Koder and Tolkien ",
 
            "#institution_id":         "",
            "institution_id":          "NCC",
@@ -61,10 +60,8 @@
            "forcing":                "TO, SO, Nat",
 
            "#parent_experiment_rip": "",
-           "parent_variant_label":  "r1i3p2",
 
            "#parent_experiment_id":  "",
-           "parent_experiment_id":   "N/A",
 
            "#branch_time":            "",
            "branch_time":             "1",

--- a/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
+++ b/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
@@ -70,8 +70,8 @@
            "branch_time":             "1",
 
 
-           "parent_activity_id": "CMIP",
-           "parent_experiment_id": "histALL",
+           "parent_activity_id": "no parent",
+           "parent_experiment_id": "no parent",
            "parent_source_id":   "GFDL-CM2-1",
            "parent_variant_label":  "r1i1p1f3",
 

--- a/Test/test_python_CMIP6_CV_forcenoparent.py
+++ b/Test/test_python_CMIP6_CV_forcenoparent.py
@@ -54,11 +54,11 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         f = open(self.tmpfile, 'r')
         lines = f.readlines()
         count = 0
-        # We need 8 attributes to be replaced
+        # We need 6 attributes to be replaced
         for line in lines:
             if line.find('replaced') != -1:
                 count = count + 1
-        self.assertEqual(count, 8)
+        self.assertEqual(count, 6)
         f.close()
 
 


### PR DESCRIPTION
Fixes #553 

This PR will make the function cmor_CV_checkExperiment throw an error if the activity_id is inconsistent with the experiment_id in CMIP6_CV.json.  This change has the same effect on parent_activity_id and parent_experiment_id attributes in the user input JSON, which required changing some of the user input examples for tests.
