### PR TITLE
Change "_control_vocabulary_file" to "_controlled_vocabulary_file" in user input file.

### DIFF
--- a/Test/CMOR_input_TestTables.json
+++ b/Test/CMOR_input_TestTables.json
@@ -57,7 +57,7 @@
  
     "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
-    "_control_vocabulary_file": "Tables/CMIP6_CV.json",
+    "_controlled_vocabulary_file": "Tables/CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "Tables/CMIP6_coordinate.json",
     "_FORMULA_VAR_FILE":        "Tables/CMIP6_formula_terms.json",
     "_cmip6_option":           "CMIP6",

--- a/Test/CMOR_input_example.json
+++ b/Test/CMOR_input_example.json
@@ -57,7 +57,7 @@
  
     "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
-    "_control_vocabulary_file": "CMIP6_CV.json",
+    "_controlled_vocabulary_file": "CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
     "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
     "_cmip6_option":           "CMIP6",

--- a/Test/baddirectory.json
+++ b/Test/baddirectory.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "CMIP6_CV.json",
+           "_controlled_vocabulary_file": "CMIP6_CV.json",
            "_cmip6_option":           "CMIP6",
 
            "tracking_prefix":        "hdl:21.14100",

--- a/Test/cmor_speed_and_compression.json
+++ b/Test/cmor_speed_and_compression.json
@@ -1,5 +1,5 @@
 {
-    "_control_vocabulary_file":     "CMIP6_CV.json",
+    "_controlled_vocabulary_file":     "CMIP6_CV.json",
     "_cmip6_option":                "CMIP6",
 
     "activity_id":                  "CMIP",

--- a/Test/common_user_inputNOBOUNDS.json
+++ b/Test/common_user_inputNOBOUNDS.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "Tables/CMIP6_CV.json",
+           "_controlled_vocabulary_file": "Tables/CMIP6_CV.json",
            "_AXIS_ENTRY_FILE":         "CMIP6_coordinateTESTNOBOUNDS.json",
            "_FORMULA_VAR_FILE":        "Tables/CMIP6_formula_terms.json",
            "_cmip6_option":           "CMIP6",

--- a/Test/common_user_input_NOID.json
+++ b/Test/common_user_input_NOID.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "CMIP6_CV.json",
+           "_controlled_vocabulary_file": "CMIP6_CV.json",
            "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
            "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
            "_cmip6_option":           "CMIP6",

--- a/Test/common_user_input_hier.json
+++ b/Test/common_user_input_hier.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "CMIP6_CV_hierarchical.json",
+           "_controlled_vocabulary_file": "CMIP6_CV_hierarchical.json",
            "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
            "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
            "_cmip6_option":           "CMIP6",

--- a/Test/metadata-template.json
+++ b/Test/metadata-template.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "CMIP6_CV.json",
+           "_controlled_vocabulary_file": "CMIP6_CV.json",
            "_cmip6_option":           "CMIP6",
 
     "activity_id":                  "CMIP",

--- a/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
+++ b/Test/test_python_CMIP6_CV_badsourcetypeCHEMAER.json
@@ -1,5 +1,5 @@
 {
-           "_control_vocabulary_file": "CMIP6_CV.json",
+           "_controlled_vocabulary_file": "CMIP6_CV.json",
            "_cmip6_option":           "CMIP6",
 
            "tracking_prefix":        "hdl:21.14100",

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -188,7 +188,7 @@
 #define GLOBAL_ATT_TITLE_MSG          "%s output prepared for %s"
 #define GLOBAL_ATT_EXTERNAL_VAR       "external_variables"
 #define GLOBAL_ATT_MIP_ERA            "mip_era"
-#define GLOBAL_CV_FILENAME            GLOBAL_INTERNAL"control_vocabulary_file"
+#define GLOBAL_CV_FILENAME            GLOBAL_INTERNAL"controlled_vocabulary_file"
 #define GLOBAL_IS_CMIP6               GLOBAL_INTERNAL"cmip6_option"
 
 #define NO_PARENT                     "no parent"


### PR DESCRIPTION
Resolves #488 
This change is meant to maintain consistency with the https://github.com/WCRP-CMIP/CMIP6_CVs documentation mentioned in https://github.com/PCMDI/cmor3_documentation/issues/55.