### PR TITLE
Output file names for errors in PrePARE

### DIFF
--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -439,6 +439,7 @@ class checkCMIP6(object):
         if variable_cmor_entry not in list(cmor_table['variable_entry'].keys()):
             msg = "The entry " + variable_cmor_entry + " could not be found in CMOR table"
             self.prepare_print(msg, 'FAIL', no_text_color, lines=True)
+            self.prepare_print("└──> :: CV FAIL    :: {}".format(ncfile), 'FAIL', no_text_color)
             raise KeyboardInterrupt
         variable_record_name = cmor_table['variable_entry'][variable_cmor_entry]['out_name']
         # Variable id attribute should be the same as variable record name
@@ -467,6 +468,7 @@ class checkCMIP6(object):
         except BaseException:
             msg = "The variable " + variable_record_name + " could not be found in file"
             self.prepare_print(msg, 'FAIL', no_text_color, lines=True)
+            self.prepare_print("└──> :: CV FAIL    :: {}".format(ncfile), 'FAIL', no_text_color)
             raise KeyboardInterrupt
 
         # -------------------------------------------------------------------
@@ -572,6 +574,7 @@ class checkCMIP6(object):
         if varid == -1:
             msg = "Could not find variable {} in table {} ".format(variable_cmor_entry, cmip6_table)
             self.prepare_print(msg, 'FAIL', no_text_color, lines=True)
+            self.prepare_print("└──> :: CV FAIL    :: {}".format(ncfile), 'FAIL', no_text_color)
             raise KeyboardInterrupt
         # -------------------------------------------------------------------
         # Check filename


### PR DESCRIPTION
@alaniwi
PrePARE will output the file's name for most errors.  However, there were three kinds of errors where PrePARE did not output a name.

These errors are when:
* The variable is not found in the table.
* The variable in the file name is not in the file.
* The variable does not have an entry in the table.

This was why the file name was not displayed for the error in https://github.com/PCMDI/cmor/issues/534#issue-479264683.  This PR will make PrePARE output the file names for files with these errors.  This may also satisfy #533 since PrePARE already reports file names for other errors.