### PR TITLE
Fix miniconda setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
       else
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
       fi
-      bash miniconda.sh -b -p $WORKDIR
+      bash miniconda.sh -b -p $WORKDIR/miniconda
       
   - &create_conda_env
     name: create_conda_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,13 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      mkdir -p workspace
-      git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
-      ls workspace/cdat
-      # following will install miniconda3 under $WORKDIR/miniconda/bin
-      python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p py$PYTHON_VERSION
+      mkdir -p $WORKDIR
+      if [[ $OS != 'osx-64' ]]; then
+        curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+      else
+        curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+      fi
+      bash miniconda.sh -b -p $WORKDIR
       
   - &create_conda_env
     name: create_conda_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
     name: setup_miniconda
     command: |
       mkdir -p $WORKDIR
-      if [[ $OS != 'osx-64' ]]; then
+      if [[ $OS == 'osx-64' ]]; then
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
       else
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh


### PR DESCRIPTION
The miniconda setup script from the CDAT repo was not working for the OSX builds in CircleCI.  This was due to the `curl` command needing the `-L` option for following redirects.  I have replaced the cloning of the CDAT repo with lines in config.yml that download and run the miniconda bash script.