### PR TITLE
Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,27 @@ jobs:
       - run: *run_prepare_tests
       - run: *conda_upload
 
+  macos_cmor_py38:
+    macos:
+      xcode: "11.1.0"
+    environment:
+      PYTHON_VERSION: "3.8"
+      WORKDIR: "workspace/test_macos_cmor"
+      CONDA_COMPILERS: "clang_osx-64>=9 gfortran_osx-64>=7"
+      LDSHARED_FLAGS: "-bundle -undefined dynamic_lookup"
+      UVCDAT_ANONYMOUS_LOG: "False"
+      OS: "osx-64"
+    steps:
+      - checkout
+      - run: *pull_submodules
+      - run: *setup_miniconda
+      - run: *create_conda_env
+      - run: *setup_cmor
+      - run: *run_cmor_tests
+      - run: *run_cmor_tests_with_cdms2
+      - run: *run_prepare_tests
+      - run: *conda_upload
+
   linux_cmor_py27:
     machine:
       image: circleci/classic:latest
@@ -229,6 +250,27 @@ jobs:
       - run: *run_prepare_tests
       - run: *conda_upload
 
+  linux_cmor_py38:
+    machine:
+      image: circleci/classic:latest
+    environment:
+      PYTHON_VERSION: "3.8"
+      WORKDIR: "workspace/test_linux_cmor"
+      CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7"
+      LDSHARED_FLAGS: "-shared -pthread"
+      UVCDAT_ANONYMOUS_LOG: "False"
+      OS: "linux-64"
+    steps:
+      - checkout
+      - run: *pull_submodules
+      - run: *setup_miniconda
+      - run: *create_conda_env
+      - run: *setup_cmor
+      - run: *run_cmor_tests
+      - run: *run_cmor_tests_with_cdms2
+      - run: *run_prepare_tests
+      - run: *conda_upload
+
 workflows:
   version: 2
   nightly:
@@ -236,6 +278,8 @@ workflows:
       - macos_cmor_py27
       - macos_cmor_py36
       - macos_cmor_py37
+      - macos_cmor_py38
       - linux_cmor_py27
       - linux_cmor_py36
       - linux_cmor_py37
+      - linux_cmor_py38

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .cproject
 .project
 .settings/
+.vscode/
 Test/CMIP5
 CMIP5
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - CMOR_PYTHON_VERSION='2.7'
   - CMOR_PYTHON_VERSION='3.6'
   - CMOR_PYTHON_VERSION='3.7'
+  - CMOR_PYTHON_VERSION='3.8'
 services:
   - docker
 

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -593,15 +593,8 @@ def zfactor(zaxis_id, zfactor_name, units="", axis_ids=None,
 
     if axis_ids is None:
         ndims = 0
-        axis_ids = numpy.array(1)
     else:
         ndims = len(axis_ids)
-
-# if ndims>1 and zfactor_values is not None:
-##         raise Exception, "Error you can only pass zfactor_values for zfactor with rank <=1"
-# if ndims>1 and zfactor_bounds is not None:
-# raise Exception, "Error you can only pass zfactor_bounds for zfactor
-# with rank <=1"
 
     if zfactor_values is not None:
         if isinstance(zfactor_values, (float, int, numpy.float,
@@ -673,10 +666,10 @@ def zfactor(zaxis_id, zfactor_name, units="", axis_ids=None,
                         "error zfactor_bounds have gaps between them")
             bnds.append(zfactor_bounds[-1][1])
             zfactor_bounds = numpy.array(bnds)
-    axis_ids = axis_ids.astype('i')
+            
+    if axis_ids is not None:
+        axis_ids = axis_ids.astype('i')
 
-# print
-# "sending",zaxis_id,zfactor_name,units,ndims,axis_ids,data_type,zfactor_values,zfactor_bounds
     return _cmor.zfactor(zaxis_id, zfactor_name, units,
                          ndims, axis_ids, str.encode(data_type), zfactor_values, zfactor_bounds)
 

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -671,7 +671,7 @@ static PyObject *PyCMOR_zfactor(PyObject * self, PyObject * args)
     if (axes_obj == Py_None) {
         axes_ids = NULL;
     } else {
-        if (PyArray_Check(axes_obj)) {
+        if (!PyArray_CheckAnyScalar(axes_obj)) {
             axes =
               (PyArrayObject *) PyArray_ContiguousFromObject(axes_obj,
                                                              NPY_NOTYPE, 1, 0);
@@ -824,7 +824,7 @@ static PyObject *PyCMOR_write(PyObject * self, PyObject * args)
     if (times_obj == Py_None) {
         times = NULL;
     } else {
-        if (ntimes > 1) {
+        if (!PyArray_CheckAnyScalar(times_obj)) {
             times_array = (PyArrayObject *)
               PyArray_ContiguousFromObject(times_obj, NPY_NOTYPE, 1, 0);
             times = (void *)PyArray_DATA(times_array);

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -671,19 +671,10 @@ static PyObject *PyCMOR_zfactor(PyObject * self, PyObject * args)
     if (axes_obj == Py_None) {
         axes_ids = NULL;
     } else {
-        if (ndims > 1) {
-            axes =
-              (PyArrayObject *) PyArray_ContiguousFromObject(axes_obj,
-                                                             NPY_NOTYPE, 1, 0);
-            axes_ids = (void *)PyArray_DATA(axes);
-        } else {
-#if PY_MAJOR_VERSION >= 3
-            itmp = (int)PyLong_AsLong(axes_obj);
-#else
-            itmp = (int)PyInt_AsLong(axes_obj);
-#endif
-            axes_ids = &itmp;
-        }
+        axes =
+            (PyArrayObject *) PyArray_ContiguousFromObject(axes_obj,
+                                                            NPY_NOTYPE, 1, 0);
+        axes_ids = (void *)PyArray_DATA(axes);
     }
 
     if (values_obj == Py_None) {

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -671,10 +671,19 @@ static PyObject *PyCMOR_zfactor(PyObject * self, PyObject * args)
     if (axes_obj == Py_None) {
         axes_ids = NULL;
     } else {
-        axes =
-            (PyArrayObject *) PyArray_ContiguousFromObject(axes_obj,
-                                                            NPY_NOTYPE, 1, 0);
-        axes_ids = (void *)PyArray_DATA(axes);
+        if (PyArray_Check(axes_obj)) {
+            axes =
+              (PyArrayObject *) PyArray_ContiguousFromObject(axes_obj,
+                                                             NPY_NOTYPE, 1, 0);
+            axes_ids = (void *)PyArray_DATA(axes);
+        } else {
+#if PY_MAJOR_VERSION >= 3
+            itmp = (int)PyLong_AsLong(axes_obj);
+#else
+            itmp = (int)PyInt_AsLong(axes_obj);
+#endif
+            axes_ids = &itmp;
+        }
     }
 
     if (values_obj == Py_None) {

--- a/Src/_controlvocabulary.c
+++ b/Src/_controlvocabulary.c
@@ -652,7 +652,7 @@ static PyMethodDef MyExtractMethods[] = {
     {"getCMOR_defaults_include", PyCMOR_getincvalues, METH_VARARGS},
     {"setup_variable", PyCV_setup_variable, METH_VARARGS},
     {"get_CV_Error", PyCV_get_Error, METH_VARARGS},
-    {"reset_CV_Error", PyCV_reset_Error},
+    {"reset_CV_Error", PyCV_reset_Error, METH_VARARGS},
     {"set_CV_Error", PyCV_set_Error, METH_VARARGS},
 
     {NULL, NULL}                /*sentinel */

--- a/Test/test_python_user_interface_00.py
+++ b/Test/test_python_user_interface_00.py
@@ -113,17 +113,17 @@ print('vars 2')
 
 myvars[3] = cmor.zfactor(int(myaxes2[1]), "p0", "Pa", None, 'd', p0)
 print('zfact', myaxes2[1])
-myvars[3] = cmor.zfactor(int(myaxes2[1]), "b", "",
+myvars[4] = cmor.zfactor(int(myaxes2[1]), "b", "",
                          myaxes2[1], 'd', b_coeff, b_coeff_bnds)
 print('zfact', myaxes2[1])
-myvars[3] = cmor.zfactor(int(myaxes2[1]), "a", "",
+myvars[5] = cmor.zfactor(int(myaxes2[1]), "a", "",
                          myaxes2[1], 'd', a_coeff, a_coeff_bnds)
 #/*   printf("defining ap\n"); */
 #/*   for(i=0;i<5;i++) {a_coeff[i]*=1.e3;printf("sending acoef: %i, %lf\n",i,a_coeff[i]);} */
 #/*   for(i=0;i<6;i++) {a_coeff_bnds[i]*=1.e5;printf("sending acoef: %i, %lf\n",i,a_coeff_bnds[i]);} */
 #/*   ierr = cmor_zfactor(&myvars[3],myaxes2[1],"ap","hPa",1,&myaxes2[1],'d',&a_coeff,&a_coeff_bnds); */
 print('zfact before last')
-myvars[3] = cmor.zfactor(zaxis_id=myaxes2[1],
+myvars[6] = cmor.zfactor(zaxis_id=myaxes2[1],
                          zfactor_name="ps",
                          units="hPa",
                          axis_ids=myaxes[:3],
@@ -136,7 +136,7 @@ myaxes2[0] = myaxes[7]
 myaxes2[1] = myaxes[5]
 myaxes2[2] = myaxes[8]
 
-myvars[4] = cmor.variable("htovgyre",
+myvars[7] = cmor.variable("htovgyre",
                           "W",
                           myaxes2[:3],
                           'd',


### PR DESCRIPTION
Adding support for Python 3.8 to CMOR.

Some changes needed to be made in _cmormodule.c for changes in 3.8.  `PyCMOR_zfactor` was having issues with list of axis ids that had a length of one as it was trying to read them as scalars using `PyLong_AsLong`.  This was causing an error in this section of a test.
https://github.com/PCMDI/cmor/blob/2b8af958b0615c975005dfec361edd3f3ce67c35/Test/test_python_user_interface_00.py#L116-L120
To fix this, I replaced checking if the number of axis ids was greater than 1 with checking if the axis id object was a scalar using `PyArray_CheckAnyScalar`.
https://github.com/PCMDI/cmor/blob/53d53fc51246556b3a406c12bfd2091792fc9078/Src/_cmormodule.c#L674-L686
There was a similar section in `PyCMOR_write` with the number of times passed.  This was not causing issues with tests but I applied the same logic as with the zfactor axis ids to the time passed.  This is just in case `PyFloat_AsDouble` exhibits the same behavior.
https://github.com/PCMDI/cmor/blob/53d53fc51246556b3a406c12bfd2091792fc9078/Src/_cmormodule.c#L827-L834
From https://docs.python.org/3/whatsnew/3.8.html

> Functions that convert Python number to C integer like PyLong_AsLong() and argument parsing functions like PyArg_ParseTuple() with integer converting format units like 'i' will now use the __index__() special method instead of __int__(), if available. The deprecation warning will be emitted for objects with the __int__() method but without the __index__() method (like Decimal and Fraction). PyNumber_Check() will now return 1 for objects implementing __index__(). PyNumber_Long(), PyNumber_Float() and PyFloat_AsDouble() also now use the __index__() method if available. (Contributed by Serhiy Storchaka in bpo-36048 and bpo-20092.) 

