### PR TITLE
libnetcdf update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.4 netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.3 netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
+       conda create -q -n py$PYTHON_VERSION -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.4 netcdf4 numpy openssl lazy-object-proxy python=$PYTHON_VERSION $CONDA_COMPILERS testsrunner
 
   - &setup_cmor
     name: setup_cmor

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .cproject
 .project
 .settings/
+.vscode
 Test/CMIP5
 CMIP5
 Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.4 netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - conda update -y -q conda
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CONDA_COMPILERS="gcc_linux-64 gfortran_linux-64"; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then export CONDA_COMPILERS="clang_osx-64 gfortran_osx-64"; fi
-  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.3 netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
+  - conda create -q -n py${CMOR_PYTHON_VERSION} -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 openblas==0.3.6 libnetcdf==4.7.4 netcdf4 numpy openssl lazy-object-proxy python=${CMOR_PYTHON_VERSION} $CONDA_COMPILERS testsrunner
   - source activate py${CMOR_PYTHON_VERSION}
 install:
   - export PREFIX=$(python -c "import sys; print(sys.prefix)")

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -27,7 +27,7 @@ requirements:
     - json-c
     - hdf5
     - openblas 0.3.6
-    - libnetcdf 4.7.3
+    - libnetcdf 4.7.4
     - netcdf4
     - numpy >=1.14.6
     - setuptools
@@ -39,7 +39,7 @@ requirements:
     - json-c
     - numpy >=1.14.6
     - openblas 0.3.6
-    - libnetcdf 4.7.3
+    - libnetcdf 4.7.4
     - {{ pin_compatible('hdf5') }}
     - {{ pin_compatible('netcdf4') }}
 

--- a/recipes/cmor/meta.yaml.in
+++ b/recipes/cmor/meta.yaml.in
@@ -27,7 +27,7 @@ requirements:
     - json-c
     - hdf5
     - openblas 0.3.6
-    - libnetcdf 4.7.4
+    - libnetcdf
     - netcdf4
     - numpy >=1.14.6
     - setuptools
@@ -39,7 +39,7 @@ requirements:
     - json-c
     - numpy >=1.14.6
     - openblas 0.3.6
-    - libnetcdf 4.7.4
+    - libnetcdf
     - {{ pin_compatible('hdf5') }}
     - {{ pin_compatible('netcdf4') }}
 


### PR DESCRIPTION
This will unpin libnetcdf 4.7.3 from the nightly build to allow libnetcdf 4.7.4 to be used by the Python 3.6, 3.7, and 3.8 builds, while the Python 2.7 builds will still use libnetcdf 4.7.3.