### PR TITLE
Pin gfortran 7.5.0 for OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
       PYTHON_VERSION: "3.6"
       CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
       PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7"
+      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7.5"
       WORKDIR: "macos_build"
     steps:
       - checkout
@@ -159,7 +159,7 @@ jobs:
       PYTHON_VERSION: "3.7"
       CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
       PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7"
+      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7.5"
       WORKDIR: "macos_build"
     steps:
       - checkout
@@ -186,7 +186,7 @@ jobs:
       PYTHON_VERSION: "3.8"
       CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
       PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7"
+      CONDA_COMPILERS: "clang_osx-64==9.0.1 gfortran_osx-64>=7.5"
       WORKDIR: "macos_build"
     steps:
       - checkout

--- a/recipes/cmor/conda_build_config.yaml
+++ b/recipes/cmor/conda_build_config.yaml
@@ -2,5 +2,5 @@ python:
     - 3.6
     - 3.7
     - 3.8
-fortran_compiler_version:   # [linux]
-    - 7.5.0                 # [linux]
+fortran_compiler_version:
+    - 7.5.0


### PR DESCRIPTION
A recent change to the OSX Fortran compiler is causing issues similar to the one in #614.  This will apply the same pinning of gfortran to OSX builds.