### PR TITLE
Updated CircleCI config and Python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ aliases:
       else
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
       fi
-      bash miniconda.sh -b -p $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda
-      git clone -b master https://github.com/CDAT/conda-recipes $CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes
+      bash miniconda.sh -b -p `pwd`/$WORKDIR/miniconda
+      git clone -b master https://github.com/CDAT/conda-recipes `pwd`/$WORKDIR/conda-recipes
 
-      source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+      source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
       conda activate base
       conda config --set always_yes yes --set changeps1 no
       conda update -y -q conda
@@ -32,35 +32,35 @@ aliases:
   - &conda_rerender
     name: conda_rerender
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
 
-       export BUILD_SCRIPT=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/bin/activate
+       export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
        python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b master --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
        
   - &conda_build
     name: conda_build
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
 
-       export ARTIFACT_DIR=$CIRCLE_WORKING_DIRECTORY/artifacts.$OS.py_$PYTHON_VERSION
+       export ARTIFACT_DIR=`pwd`/artifacts.$OS.py_$PYTHON_VERSION
        mkdir $ARTIFACT_DIR
        
        export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
-       export BUILD_SCRIPT=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/bin/activate
+       export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
        python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -73,7 +73,7 @@ aliases:
   - &run_cmor_tests_with_cdms2
     name: run_cmor_tests_with_cdms2
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        # run tests again but with cdms2 installed
@@ -86,7 +86,7 @@ aliases:
   - &run_prepare_tests
     name: run_prepare_tests
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -99,10 +99,10 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
-       export CONDA_BLD_PATH=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/conda-bld
+       export CONDA_BLD_PATH=`pwd`/$WORKDIR/miniconda/conda-bld
        ls $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.*.tar.bz2
        if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ aliases:
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
       fi
       bash miniconda.sh -b -p `pwd`/$WORKDIR/miniconda
-      git clone -b master https://github.com/CDAT/conda-recipes `pwd`/$WORKDIR/conda-recipes
        
   - &conda_rerender
     name: conda_rerender
@@ -30,6 +29,7 @@ aliases:
        conda activate base
        conda config --set anaconda_upload no
 
+       git clone -b master https://github.com/CDAT/conda-recipes `pwd`/$WORKDIR/conda-recipes
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,16 +133,12 @@ jobs:
          os:
             type: executor
       executor: << parameters.os >>
-      environment:
-         PKG_NAME: "cmor"
-         VERSION: "3.6.0"
       steps:
          - checkout
          - attach_workspace:
               at: .
          - run: *setup_env
          - run: *setup_miniconda
-         - run: *conda_rerender
          - persist_to_workspace:
               root: .
               paths:
@@ -157,40 +153,25 @@ jobs:
       executor: << parameters.os >>
       environment:
          PKG_NAME: "cmor"
+         VERSION: "3.6.0"
          PYTHON_VERSION: << parameters.python_version >>
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *setup_env
-         - run: *conda_build
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - workdir
-                 - artifacts
-
-   test:
-      parameters:
-         os:
-            type: executor
-         python_version: 
-            type: string
-      executor: << parameters.os >>
-      environment:
-         PKG_NAME: "cmor"
          CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
          PKGS: " lazy-object-proxy testsrunner"
-         PYTHON_VERSION: << parameters.python_version >>
       steps:
          - checkout
          - attach_workspace:
               at: .
          - run: *setup_env
+         - run: *conda_rerender
+         - run: *conda_build
          - run: *pull_submodules
          - run: *run_cmor_tests
          - run: *run_cmor_tests_with_cdms2
          - run: *run_prepare_tests
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - artifacts
 
    upload:
       parameters:
@@ -225,22 +206,13 @@ workflows:
               requires:
                  - setup-<< matrix.os >>
 
-         - test:
-              matrix:
-                 parameters:
-                    os: [ linux, macos ]
-                    python_version: [ "3.6", "3.7", "3.8" ]
-              name: test-<< matrix.os >>-<< matrix.python_version >>
-              requires:
-                 - build-<< matrix.os >>-<< matrix.python_version >>
-
          - upload:
               matrix:
                  parameters:
                     os: [ linux ]
               name: upload
               requires:
-                 - test
+                 - build
               filters:
                  branches:
                     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ workflows:
               matrix:
                  parameters:
                     os: [ linux, macos ]
-                    python_version: [ "3.6", "3.7", "3.8" ]
+                    python_version: [ "3.6", "3.7", "3.8", "3.9" ]
               name: build-<< matrix.os >>-<< matrix.python_version >>
               requires:
                  - setup-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 checkout:
   post:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ aliases:
        conda activate base
        conda config --set anaconda_upload no
 
-       export ARTIFACT_DIR=`pwd`/artifacts.$OS.py_$PYTHON_VERSION
+       export ARTIFACT_DIR=`pwd`/artifacts
        mkdir $ARTIFACT_DIR
        
        export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
@@ -101,7 +101,7 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
-       export ARTIFACT_DIR=`pwd`/artifacts.$OS.py_$PYTHON_VERSION
+       export ARTIFACT_DIR=`pwd`/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*.tar.bz2 --force
 
 
@@ -128,6 +128,8 @@ jobs:
             type: string
       executor: << parameters.os >>
       environment:
+         PKG_NAME: "cmor"
+         VERSION: "3.6.0"
          PYTHON_VERSION: << parameters.python_version >>
       steps:
          - checkout
@@ -152,8 +154,6 @@ jobs:
       executor: << parameters.os >>
       environment:
          PKG_NAME: "cmor"
-         VERSION: "3.6.0"
-         LABEL: "nightly"
          CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
          PKGS: " lazy-object-proxy testsrunner"
          PYTHON_VERSION: << parameters.python_version >>
@@ -178,7 +178,6 @@ jobs:
       environment:
          USER: "pcmdi"
          LABEL: "nightly"
-         PYTHON_VERSION: "3.7"
       steps:
          - checkout
          - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
          - persist_to_workspace:
               root: .
               paths:
-                 - workdir/<< parameters.os >>/miniconda/conda-bld
+                 - workdir
                  - artifacts
 
    test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ aliases:
        conda config --set anaconda_upload no
 
        export ARTIFACT_DIR=`pwd`/artifacts/artifacts.$OS.py_$PYTHON_VERSION
-       mkdir $ARTIFACT_DIR
+       mkdir -p $ARTIFACT_DIR
        
        export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
        export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b $CIRCLE_BRANCH --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b $CIRCLE_BRANCH --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
        
   - &conda_build
     name: conda_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,14 +112,14 @@ aliases:
 
 
 executors:
-   linux-64:
+   linux:
       machine:
          image: circleci/classic:latest
       environment:
         OS: "linux-64"
         PROJECT_DIR: "workdir/linux"
         CONDA_COMPILERS: "gcc_linux-64 gfortran_linux-64"
-   osx-64:
+   macos:
       macos:
          xcode: "11.4.0"
       environment:
@@ -128,6 +128,26 @@ executors:
         CONDA_COMPILERS: "clang_osx-64 gfortran_osx-64"
          
 jobs:
+   setup:
+      parameters:
+         os:
+            type: executor
+      executor: << parameters.os >>
+      environment:
+         PKG_NAME: "cmor"
+         VERSION: "3.6.0"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_env
+         - run: *setup_miniconda
+         - run: *conda_rerender
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - workdir
+
    build:
       parameters:
          os:
@@ -137,20 +157,17 @@ jobs:
       executor: << parameters.os >>
       environment:
          PKG_NAME: "cmor"
-         VERSION: "3.6.0"
          PYTHON_VERSION: << parameters.python_version >>
       steps:
          - checkout
          - attach_workspace:
               at: .
          - run: *setup_env
-         - run: *setup_miniconda
-         - run: *conda_rerender
          - run: *conda_build
          - persist_to_workspace:
               root: .
               paths:
-                 - workdir
+                 - workdir/<< parameters.os >>/miniconda/conda-bld/*/*.tar.bz2
                  - artifacts
 
    test:
@@ -176,8 +193,10 @@ jobs:
          - run: *run_prepare_tests
 
    upload:
-      machine:
-         image: circleci/classic:latest
+      parameters:
+         os:
+            type: executor
+      executor: << parameters.os >>
       environment:
          USER: "pcmdi"
          LABEL: "nightly"
@@ -194,20 +213,32 @@ workflows:
          - build:
               matrix:
                  parameters:
-                    os: [ linux-64, osx-64 ]
+                    os: [ linux, macos ]
+              name: setup-<< matrix.os >>
+
+         - build:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
                     python_version: [ "3.6", "3.7", "3.8" ]
               name: build-<< matrix.os >>-<< matrix.python_version >>
+              requires:
+                 - setup-<< matrix.os >>
 
          - test:
               matrix:
                  parameters:
-                    os: [ linux-64, osx-64 ]
+                    os: [ linux, macos ]
                     python_version: [ "3.6", "3.7", "3.8" ]
               name: test-<< matrix.os >>-<< matrix.python_version >>
               requires:
                  - build-<< matrix.os >>-<< matrix.python_version >>
 
          - upload:
+              matrix:
+                 parameters:
+                    os: [ linux ]
+              name: upload
               requires:
                  - test
               filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b $CIRCLE_BRANCH --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
+        --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
        
   - &conda_build
     name: conda_build
@@ -49,7 +50,8 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build \
+        --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,11 @@ aliases:
   - &setup_env
     name: setup_env
     command: |
-       export PROJECT_DIR=/home/circleci/project/workdir/$OS
+       if [[ $OS == "osx-64" ]]; then
+          export PROJECT_DIR=/Users/distiller/project/workdir/osx-64
+       else
+          export PROJECT_DIR=/home/circleci/project/workdir/linux-64
+       fi
        echo "export WORKDIR=$PROJECT_DIR/$PYTHON_VERSION" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ executors:
       machine:
          image: circleci/classic:latest
       environment:
-        OS: "linux-64"
+        OS: "linux"
         CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
    osx-64:
       macos:
          xcode: "11.4.0"
       environment:
-        OS: "osx-64"
+        OS: "macos"
         CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
          
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
          - persist_to_workspace:
               root: .
               paths:
-                 - workdir/<< parameters.os >>/miniconda/conda-bld/*/*.tar.bz2
+                 - workdir/<< parameters.os >>/miniconda/conda-bld
                  - artifacts
 
    test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,14 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
+       source $BASH_ENV
        git clone https://github.com/CDAT/cdat.git $WORKDIR/cdat
        python $WORKDIR/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
        
   - &conda_rerender
     name: conda_rerender
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
@@ -42,6 +44,7 @@ aliases:
   - &conda_build
     name: conda_build
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
@@ -59,6 +62,7 @@ aliases:
   - &run_cmor_tests
     name: run_cmor_tests
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
@@ -72,6 +76,7 @@ aliases:
   - &run_cmor_tests_with_cdms2
     name: run_cmor_tests_with_cdms2
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
@@ -85,6 +90,7 @@ aliases:
   - &run_prepare_tests
     name: run_prepare_tests
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
@@ -98,6 +104,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
+       source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,13 @@ checkout:
     - ./ci-support/checkout_merge_commit.sh
         
 aliases:
+  - &setup_env
+    name: setup_env
+    command: |
+       export PROJECT_DIR=/home/circleci/project/workdir/$OS
+       echo "export WORKDIR=$PROJECT_DIR/$PY_VER" >> $BASH_ENV
+       source $BASH_ENV
+       mkdir -p $WORKDIR
 
   - &pull_submodules
     name: pull_submodules
@@ -15,27 +22,27 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-       git clone https://github.com/CDAT/cdat.git `pwd`/$WORKDIR/cdat
-       python $WORKDIR/cdat/scripts/install_miniconda.py -w `pwd`/$WORKDIR -p 'py3'
+       git clone https://github.com/CDAT/cdat.git $WORKDIR/cdat
+       python $WORKDIR/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
        
   - &conda_rerender
     name: conda_rerender
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
 
-       git clone -b master https://github.com/CDAT/conda-recipes `pwd`/$WORKDIR/conda-recipes
-       export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
+       git clone -b master https://github.com/CDAT/conda-recipes $WORKDIR/conda-recipes
+       export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
+       python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
         --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
        
   - &conda_build
     name: conda_build
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
 
@@ -43,16 +50,16 @@ aliases:
        mkdir $ARTIFACT_DIR
        
        export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
-       export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
+       export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build \
+       python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build \
         --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -65,7 +72,7 @@ aliases:
   - &run_cmor_tests_with_cdms2
     name: run_cmor_tests_with_cdms2
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        # run tests again but with cdms2 installed
@@ -78,7 +85,7 @@ aliases:
   - &run_prepare_tests
     name: run_prepare_tests
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -91,283 +98,118 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
-       export CONDA_BLD_PATH=`pwd`/$WORKDIR/miniconda/conda-bld
-       ls $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.*.tar.bz2
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
-          exit 0
-       fi
-       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.*.tar.bz2 --force
+       export ARTIFACT_DIR=`pwd`/artifacts.$OS.py_$PYTHON_VERSION
+       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*.tar.bz2 --force
 
 
+executors:
+   linux-64:
+      machine:
+         image: circleci/classic:latest
+      environment:
+        OS: "linux-64"
+        CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
+   osx-64:
+      macos:
+         xcode: "11.4.0"
+      environment:
+        OS: "osx-64"
+        CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
+         
 jobs:
-  macos_setup:
-    macos:
-      xcode: "11.4.0"
-    environment:
-      OS: "osx-64"
-      WORKDIR: "macos_build"
-    steps:
-      - checkout
-      - run: *setup_miniconda
-      - persist_to_workspace:
-          root: .
-          paths: 
-            - macos_build
+   build:
+      parameters:
+         os:
+            type: executor
+         python_version: 
+            type: string
+      executor: << parameters.os >>
+      environment:
+         PYTHON_VERSION: << parameters.py_ver >>
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_env
+         - run: *setup_miniconda
+         - run: *conda_rerender
+         - run: *conda_build
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - workdir
+                 - artifacts
 
-  linux_setup:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      OS: "linux-64"
-      WORKDIR: "linux_build"
-    steps:
-      - checkout
-      - run: *setup_miniconda
-      - persist_to_workspace:
-          root: .
-          paths:
-            - linux_build
+   test:
+      parameters:
+         os:
+            type: executor
+         python_version: 
+            type: string
+         libnetcdf: 
+            type: string
+      executor: << parameters.os >>
+      environment:
+         PKG_NAME: "cmor"
+         VERSION: "3.6.0"
+         LABEL: "nightly"
+         CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
+         PKGS: " lazy-object-proxy testsrunner"
+         PYTHON_VERSION: << parameters.py_ver >>
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_env
+         - run: *run_cmor_tests
+         - run: *run_cmor_tests_with_cdms2
+         - run: *run_prepare_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+         - store_artifacts:
+              path: spec_artifacts
+              destination: spec_artifacts
 
-  macos_cmor_py36:
-    macos:
-      xcode: "11.4.0"
-    environment:
-      OS: "osx-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.6"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
-      WORKDIR: "macos_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - macos_build/miniconda/conda-bld/osx-64/cmor*.tar.bz2
-
-  macos_cmor_py37:
-    macos:
-      xcode: "11.4.0"
-    environment:
-      OS: "osx-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.7"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
-      WORKDIR: "macos_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - macos_build/miniconda/conda-bld/osx-64/cmor*.tar.bz2
-
-  macos_cmor_py38:
-    macos:
-      xcode: "11.4.0"
-    environment:
-      OS: "osx-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.8"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
-      WORKDIR: "macos_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - macos_build/miniconda/conda-bld/osx-64/cmor*.tar.bz2
-
-  linux_cmor_py36:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      OS: "linux-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.6"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
-      WORKDIR: "linux_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - linux_build/miniconda/conda-bld/linux-64/cmor*.tar.bz2
-
-  linux_cmor_py37:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      OS: "linux-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.7"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
-      WORKDIR: "linux_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - linux_build/miniconda/conda-bld/linux-64/cmor*.tar.bz2
-
-  linux_cmor_py38:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      OS: "linux-64"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      LABEL: "nightly"
-      PYTHON_VERSION: "3.8"
-      CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
-      PKGS: " lazy-object-proxy testsrunner"
-      CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
-      WORKDIR: "linux_build"
-    steps:
-      - checkout
-      - run: *pull_submodules
-      - attach_workspace:
-          at: .
-      - run: *conda_rerender
-      - run: *conda_build
-      - run: *run_cmor_tests
-      - run: *run_cmor_tests_with_cdms2
-      - run: *run_prepare_tests
-      - persist_to_workspace:
-          root: .
-          paths:
-              - linux_build/miniconda/conda-bld/linux-64/cmor*.tar.bz2
-
-  macos_upload:
-    macos:
-      xcode: "11.4.0"
-    environment:
-      OS: "osx-64"
-      WORKDIR: "macos_build"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      USER: "pcmdi"
-      LABEL: "nightly"
-    steps:
-      - attach_workspace:
-          at: .
-      - run: pwd
-      - run: *conda_upload
-      
-  linux_upload:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      OS: "linux-64"
-      WORKDIR: "linux_build"
-      PKG_NAME: "cmor"
-      VERSION: "3.6.0"
-      USER: "pcmdi"
-      LABEL: "nightly"
-    steps:
-      - attach_workspace:
-          at: .
-      - run: pwd
-      - run: *conda_upload
+   upload:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         USER: "pcmdi"
+         LABEL: "nightly"
+         PYTHON_VERSION: "3.7"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_env
+         - run: *conda_upload
 
 workflows:
-  version: 2
-  nightly:
-    jobs:
-      - macos_setup
-      - linux_setup
-      - macos_cmor_py36:
-          requires:
-            - macos_setup
-      - macos_cmor_py37:
-          requires:
-            - macos_setup
-      - macos_cmor_py38:
-          requires:
-            - macos_setup
-      - linux_cmor_py36:
-          requires:
-            - linux_setup
-      - linux_cmor_py37:
-          requires:
-            - linux_setup
-      - linux_cmor_py38:
-          requires:
-            - linux_setup
-      - macos_upload:
-          requires:
-            - macos_cmor_py36
-            - macos_cmor_py37
-            - macos_cmor_py38
-          filters:
-            branches:
-              only: master
-      - linux_upload:
-          requires:
-            - linux_cmor_py36
-            - linux_cmor_py37
-            - linux_cmor_py38
-          filters:
-            branches:
-              only: master
+   vcsaddons:
+      jobs:
+         - build:
+              matrix:
+                 parameters:
+                    os: [ linux-64, osx-64 ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+              name: build-<< matrix.os >>-<< matrix.py_ver >>
+
+         - test:
+              matrix:
+                 parameters:
+                    os: [ linux-64, osx-64 ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+              name: test-<< matrix.os >>-<< matrix.py_ver >>
+              requires:
+                 - build-<< matrix.os >>-<< matrix.py_ver >>
+
+         - upload:
+              requires:
+                 - test
+              filters:
+                 branches:
+                    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
 workflows:
    cmor:
       jobs:
-         - build:
+         - setup:
               matrix:
                  parameters:
                     os: [ linux, macos ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,8 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      if [[ $OS == 'osx-64' ]]; then
-        curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
-      else
-        curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
-      fi
-      bash miniconda.sh -b -p `pwd`/$WORKDIR/miniconda
+       git clone https://github.com/CDAT/cdat.git `pwd`/$WORKDIR/cdat
+       python $WORKDIR/cdat/scripts/install_miniconda.py -w `pwd`/$WORKDIR -p 'py3'
        
   - &conda_rerender
     name: conda_rerender

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
   - &setup_env
     name: setup_env
     command: |
-       echo "export WORKDIR=`pwd`/$OS" >> $BASH_ENV
+       echo "export WORKDIR=`pwd`/$PROJECT_DIR" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR
 
@@ -116,13 +116,15 @@ executors:
       machine:
          image: circleci/classic:latest
       environment:
-        OS: "linux"
+        OS: "linux-64"
+        PROJECT_DIR: "workdir/linux"
         CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
    osx-64:
       macos:
          xcode: "11.4.0"
       environment:
-        OS: "macos"
+        OS: "osx-64"
+        PROJECT_DIR: "workdir/macos"
         CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
          
 jobs:
@@ -172,12 +174,6 @@ jobs:
          - run: *run_cmor_tests
          - run: *run_cmor_tests_with_cdms2
          - run: *run_prepare_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-              path: spec_artifacts
-              destination: spec_artifacts
 
    upload:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ jobs:
          - attach_workspace:
               at: .
          - run: *setup_env
+         - run: *pull_submodules
          - run: *run_cmor_tests
          - run: *run_cmor_tests_with_cdms2
          - run: *run_prepare_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ aliases:
        else
           export PROJECT_DIR=/home/circleci/project/workdir/linux-64
        fi
-       echo "export WORKDIR=$PROJECT_DIR/$PYTHON_VERSION" >> $BASH_ENV
+       echo "export WORKDIR=$PROJECT_DIR.$PYTHON_VERSION" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,28 +21,46 @@ aliases:
         curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
       fi
       bash miniconda.sh -b -p $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda
+      git clone -b master https://github.com/CDAT/conda-recipes $CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes
 
-      source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+      source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
       conda activate base
       conda config --set always_yes yes --set changeps1 no
       conda update -y -q conda
       conda install conda-build anaconda-client
        
-  - &conda_build
-    name: conda_build
+  - &conda_rerender
+    name: conda_rerender
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
 
-       cd recipes
-       python ./prep_for_build.py -l $VERSION
-       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=$PYTHON_VERSION
+       export BUILD_SCRIPT=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/bin/activate
+
+       python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b master --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
+       
+  - &conda_build
+    name: conda_build
+    command: |
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       conda activate base
+       conda config --set anaconda_upload no
+
+       export ARTIFACT_DIR=$CIRCLE_WORKING_DIRECTORY/artifacts.$OS.py_$PYTHON_VERSION
+       mkdir $ARTIFACT_DIR
+       
+       export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
+       export BUILD_SCRIPT=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/conda-recipes/build_tools/conda_build.py
+       export ACTIVATE=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/bin/activate
+
+       python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -55,7 +73,7 @@ aliases:
   - &run_cmor_tests_with_cdms2
     name: run_cmor_tests_with_cdms2
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        # run tests again but with cdms2 installed
@@ -68,7 +86,7 @@ aliases:
   - &run_prepare_tests
     name: run_prepare_tests
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        export UVCDAT_ANONYMOUS_LOG=False
        set +e
@@ -81,10 +99,10 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
+       source $CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
-       export CONDA_BLD_PATH=`pwd`/$WORKDIR/miniconda/conda-bld
+       export CONDA_BLD_PATH=$CIRCLE_WORKING_DIRECTORY/$WORKDIR/miniconda/conda-bld
        ls $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.*.tar.bz2
        if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
@@ -139,6 +157,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2
@@ -166,6 +185,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2
@@ -193,6 +213,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2
@@ -220,6 +241,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2
@@ -247,6 +269,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2
@@ -274,6 +297,7 @@ jobs:
       - run: *pull_submodules
       - attach_workspace:
           at: .
+      - run: *conda_rerender
       - run: *conda_build
       - run: *run_cmor_tests
       - run: *run_cmor_tests_with_cdms2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,6 @@ aliases:
       fi
       bash miniconda.sh -b -p `pwd`/$WORKDIR/miniconda
       git clone -b master https://github.com/CDAT/conda-recipes `pwd`/$WORKDIR/conda-recipes
-
-      source `pwd`/$WORKDIR/miniconda/etc/profile.d/conda.sh
-      conda activate base
-      conda config --set always_yes yes --set changeps1 no
-      conda update -y -q conda
-      conda install conda-build anaconda-client
        
   - &conda_rerender
     name: conda_rerender
@@ -39,7 +33,7 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b master --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b $CIRCLE_BRANCH --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
        
   - &conda_build
     name: conda_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
        conda activate base
        conda config --set anaconda_upload no
 
-       export ARTIFACT_DIR=`pwd`/artifacts
+       export ARTIFACT_DIR=`pwd`/artifacts/artifacts.$OS.py_$PYTHON_VERSION
        mkdir $ARTIFACT_DIR
        
        export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
@@ -113,7 +113,7 @@ aliases:
        conda activate base
        conda config --set anaconda_upload no
        export ARTIFACT_DIR=`pwd`/artifacts
-       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*.tar.bz2 --force
+       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force
 
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,7 @@ aliases:
   - &setup_env
     name: setup_env
     command: |
-       if [[ $OS == "osx-64" ]]; then
-          export PROJECT_DIR=/Users/distiller/project/workdir/osx-64
-       else
-          export PROJECT_DIR=/home/circleci/project/workdir/linux-64
-       fi
-       echo "export WORKDIR=$PROJECT_DIR.$PYTHON_VERSION" >> $BASH_ENV
+       echo "export WORKDIR=`pwd`/$OS" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b master --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -l $VERSION -B 0 -p $PKG_NAME -b master --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization pcmdi
        
   - &conda_build
     name: conda_build
@@ -55,7 +55,7 @@ aliases:
        export BUILD_SCRIPT=`pwd`/$WORKDIR/conda-recipes/build_tools/conda_build.py
        export ACTIVATE=`pwd`/$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
+       python $BUILD_SCRIPT -w `pwd`/$WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
          - run: *conda_upload
 
 workflows:
-   vcsaddons:
+   cmor:
       jobs:
          - build:
               matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,14 +118,14 @@ executors:
       environment:
         OS: "linux-64"
         PROJECT_DIR: "workdir/linux"
-        CONDA_COMPILERS: "gcc_linux-64>=7 gfortran_linux-64>=7.5"
+        CONDA_COMPILERS: "gcc_linux-64 gfortran_linux-64"
    osx-64:
       macos:
          xcode: "11.4.0"
       environment:
         OS: "osx-64"
         PROJECT_DIR: "workdir/macos"
-        CONDA_COMPILERS: "clang_osx-64==10.0.1 gfortran_osx-64>=7.5"
+        CONDA_COMPILERS: "clang_osx-64 gfortran_osx-64"
          
 jobs:
    build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
     name: setup_env
     command: |
        export PROJECT_DIR=/home/circleci/project/workdir/$OS
-       echo "export WORKDIR=$PROJECT_DIR/$PY_VER" >> $BASH_ENV
+       echo "export WORKDIR=$PROJECT_DIR/$PYTHON_VERSION" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR
 
@@ -128,7 +128,7 @@ jobs:
             type: string
       executor: << parameters.os >>
       environment:
-         PYTHON_VERSION: << parameters.py_ver >>
+         PYTHON_VERSION: << parameters.python_version >>
       steps:
          - checkout
          - attach_workspace:
@@ -149,8 +149,6 @@ jobs:
             type: executor
          python_version: 
             type: string
-         libnetcdf: 
-            type: string
       executor: << parameters.os >>
       environment:
          PKG_NAME: "cmor"
@@ -158,7 +156,7 @@ jobs:
          LABEL: "nightly"
          CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
          PKGS: " lazy-object-proxy testsrunner"
-         PYTHON_VERSION: << parameters.py_ver >>
+         PYTHON_VERSION: << parameters.python_version >>
       steps:
          - checkout
          - attach_workspace:
@@ -195,17 +193,17 @@ workflows:
               matrix:
                  parameters:
                     os: [ linux-64, osx-64 ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-              name: build-<< matrix.os >>-<< matrix.py_ver >>
+                    python_version: [ "3.6", "3.7", "3.8" ]
+              name: build-<< matrix.os >>-<< matrix.python_version >>
 
          - test:
               matrix:
                  parameters:
                     os: [ linux-64, osx-64 ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-              name: test-<< matrix.os >>-<< matrix.py_ver >>
+                    python_version: [ "3.6", "3.7", "3.8" ]
+              name: test-<< matrix.os >>-<< matrix.python_version >>
               requires:
-                 - build-<< matrix.os >>-<< matrix.py_ver >>
+                 - build-<< matrix.os >>-<< matrix.python_version >>
 
          - upload:
               requires:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - CMOR_PYTHON_VERSION='3.6'
   - CMOR_PYTHON_VERSION='3.7'
   - CMOR_PYTHON_VERSION='3.8'
+  - CMOR_PYTHON_VERSION='3.9'
 services:
   - docker
 

--- a/recipes/cmor/conda_build_config.yaml
+++ b/recipes/cmor/conda_build_config.yaml
@@ -2,5 +2,3 @@ python:
     - 3.6
     - 3.7
     - 3.8
-fortran_compiler_version:
-    - 7.5.0


### PR DESCRIPTION
closes #619 

I have updated the CircleCI config to be similar to that used by [CDAT/vcsaddons](https://github.com/CDAT/vcsaddons/blob/1b0b31fd5f8774b9bef6b42e90d1e97fc334dc67/.circleci/config.yml).  It uses the build tools from [CDAT/conda-recipes](https://github.com/CDAT/conda-recipes/tree/fbd8a0560ffa0cc1f541d33201aa879413565f81/build_tools) to build conda packages.

This PR also adds Python 3.9 support to CMOR.