### PR TITLE
fixed type checking in PrePARE

### DIFF
--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -493,13 +493,13 @@ class checkCMIP6(object):
         for attr in ['branch_time_in_child', 'branch_time_in_parent']:
             if attr in list(self.dictGbl.keys()):
                 self.set_double_value(attr)
-                if not numpy.issubdtype(self.dictGbl[attr], numpy.float64):
+                if not numpy.issubdtype(type(self.dictGbl[attr]), numpy.float64):
                     msg = "{} is not a double: {}".format(attr, type(self.dictGbl[attr]))
                     self.prepare_print(msg, 'FAIL', no_text_color, lines=True)
                     self.errors += 1
         for attr in ['realization_index', 'initialization_index', 'physics_index', 'forcing_index']:
             try:
-                if not numpy.issubdtype(self.dictGbl[attr], numpy.integer):
+                if not numpy.issubdtype(type(self.dictGbl[attr]), numpy.integer):
                     msg = "{} is not an integer: {}".format(attr, type(self.dictGbl[attr]))
                     self.prepare_print(msg, 'FAIL', no_text_color, lines=True)
                     self.errors += 1


### PR DESCRIPTION
Apologies for doing a PR with a fork.

As described by @martinjuckes in #624, the fix involves checking the type string of a global attribute, not the value of the attribute itself.

I've tested the fix with `tas_day_EC-Earth3_historical_r1i1p1f1_gr_18500101-18501231.nc`, with the following result

```
=====================================================================================
branch_time_in_child is not a double: <class 'str'>
=====================================================================================


=====================================================================================
branch_time_in_parent is not a double: <class 'str'>
=====================================================================================

└──> :: CV FAIL    :: /net/home/h04/pflorek/Documents/python/fcm/cmor/tas_day_EC-Earth3_historical_r1i1p1f1_gr_18500101-18501231.nc

Number of files scanned: 1
Number of file with error(s): 1

```