### PR TITLE
Remove Python 3.6 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ workflows:
               matrix:
                  parameters:
                     os: [ linux, macos ]
-                    python_version: [ "3.6", "3.7", "3.8", "3.9" ]
+                    python_version: [ "3.7", "3.8", "3.9" ]
               name: build-<< matrix.os >>-<< matrix.python_version >>
               requires:
                  - setup-<< matrix.os >>


### PR DESCRIPTION
Closes #635 

According to https://endoflife.date/python, Python 3.6 will have its end-of-life on December 23, 2021.  

We will discontinue Python 3.6 support in preparation for a CMOR 3.7.0 release this fall.