### PR TITLE
Reduce length of error message when value cannot be validated

### DIFF
--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2019,11 +2019,10 @@ int cmor_CV_ValidateAttribute(cmor_CV_def_t * CV, char *szKey)
         snprintf(msg, CMOR_MAX_STRING,
                  "The attribute \"%s\" could not be validated. \n! "
                  "The current input value is "
-                 "\"%s\" which is not valid \n! "
-                 "Valid values must match the regular expression:"
-                 "\n! \t[%s] \n! \n! "
-                 "Check your Control Vocabulary file \"%s\".\n! ",
-                 szKey, szValue, szValids, CV_Filename);
+                 "\"%s\", which is not valid. \n! \n! "
+                 "Valid values must match those found in the \"%s\" "
+                 "section\n! of your Control Vocabulary file \"%s\".\n! ",
+                 szKey, szValue, szKey, CV_Filename);
 
         cmor_handle_error(msg, CMOR_NORMAL);
         cmor_pop_traceback();

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2009,19 +2009,12 @@ int cmor_CV_ValidateAttribute(cmor_CV_def_t * CV, char *szKey)
 /* We could not validate this attribute, exit.                          */
 /* -------------------------------------------------------------------- */
     if (i == (attr_CV->anElements)) {
-        for (i = 0; i < attr_CV->anElements; i++) {
-            strcat(szValids, "\"");
-            strncpy(szOutput, attr_CV->aszValue[i], CMOR_MAX_STRING);
-            strcat(szValids, szOutput);
-            strcat(szValids, "\" ");
-        }
-
         snprintf(msg, CMOR_MAX_STRING,
                  "The attribute \"%s\" could not be validated. \n! "
                  "The current input value is "
                  "\"%s\", which is not valid. \n! \n! "
                  "Valid values must match those found in the \"%s\" "
-                 "section\n! of your Control Vocabulary file \"%s\".\n! ",
+                 "section\n! of your Controlled Vocabulary (CV) file \"%s\".\n! ",
                  szKey, szValue, szKey, CV_Filename);
 
         cmor_handle_error(msg, CMOR_NORMAL);

--- a/Test/test_python_CMIP6_CV_badgridresolution.py
+++ b/Test/test_python_CMIP6_CV_badgridresolution.py
@@ -59,6 +59,9 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         except BaseException:
             pass
         self.assertCV("\"335 km\"", "The current input")
+        start_line = "Error: The attribute \"nominal_resolution\" could not be validated."
+        find_line = "The current input value is \"335 km\", which is not valid."
+        self.assertCV(find_line, start_line, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #638 

This replaces the lengthy error message containing a regular expression string with a smaller message that only lists the section of the CV where the valid values for the attribute are located.  This is to help prevent the message from going over the maximum string length.

Previous message:
```
C Traceback:
! In function: _CV_ValidateAttribute
! called from: _CV_checkGblAttributes
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: The attribute "nominal_resolution" could not be validated. 
! The current input value is "335 km" which is not valid 
! Valid values must match the regular expression:
!       ["^0.5 km$" "^1 km$" "^10 km$" "^100 km$" "^1000 km$" "^10000 km$" "^1x1 degree$" "^2.5 km$" "^25 km$" "^250 km$" "^2500 km$" "^5 km$" "^50 km$" "^500 km$" "^5000 km$" ] 
! 
! Check your Control Vocabulary file "Tables/CMIP6_CV.json".
! 
!
!!!!!!!!!!!!!!!!!!!!!!!!!
```

New message:
```
C Traceback:
! In function: _CV_ValidateAttribute
! called from: _CV_checkGblAttributes
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: The attribute "nominal_resolution" could not be validated. 
! The current input value is "335 km", which is not valid. 
! 
! Valid values must match those found in the "nominal_resolution" section
! of your Control Vocabulary file "Tables/CMIP6_CV.json".
! 
!
!!!!!!!!!!!!!!!!!!!!!!!!!
```