### PR TITLE
remove unused part of the interface

### DIFF
--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -452,23 +452,6 @@ static PyObject *PyCMOR_load_table(PyObject * self, PyObject * args)
 }
 
 /************************************************************************/
-/*                 PyCMOR_calculate_leadtime_coord()                    */
-/************************************************************************/
-
-static PyObject *PyCMOR_calculate_leadtime_coord(PyObject * self, PyObject * args)
-{
-    int ret_val;
-    int var_id;
-
-    if (!PyArg_ParseTuple(args, "i", &var_id)) {
-        PyErr_Format(CMORError, "Unable to find variable", "calculate_leadtime_coord");
-        return NULL;
-    }
-    ret_val = calculate_leadtime_coord(var_id);
-    return (Py_BuildValue("i", ret_val));
-}
-
-/************************************************************************/
 /*                            PyCMOR_axis()                             */
 /************************************************************************/
 

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -1129,7 +1129,6 @@ static PyMethodDef MyExtractMethods[] = {
     {"set_grid_mapping", PyCMOR_grid_mapping, METH_VARARGS},
     {"getCMOR_defaults_include", PyCMOR_getincvalues, METH_VARARGS},
     {"close", PyCMOR_close, METH_VARARGS},
-    {"calculate_leadtime_coord", PyCMOR_calculate_leadtime_coord, METH_VARARGS},
     {"set_cur_dataset_attribute", PyCMOR_set_cur_dataset_attribute,
      METH_VARARGS},
     {"get_cur_dataset_attribute", PyCMOR_get_cur_dataset_attribute,

--- a/include/cmor_func_def.h
+++ b/include/cmor_func_def.h
@@ -108,8 +108,6 @@ extern int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
 extern void create_singleton_dimensions(int var_id, int ncid,
         int *nc_singletons, int *nc_singletons_bnds, int *dim_bnds);
 
-extern int cmor_calculate_leadtime_coord( int var_id );
-
 extern int copyfile(const char *source, const char *dest);
 
 /* ==================================================================== */


### PR DESCRIPTION
I removed two leftovers from the earlier part of the development, when one would need to perform an explicit call to the function creating the leadtime coordinate. Because it's all internalised now, there is no need for exposing that part of the CMOR code, and provide Python (or Fortran) API.