### PR TITLE
Properly remove multiple comment sections from cell_methods values

### DIFF
--- a/LibCV/PrePARE/PrePARE.py
+++ b/LibCV/PrePARE/PrePARE.py
@@ -617,8 +617,8 @@ class checkCMIP6(object):
                         table_value = file_value
                 if key == "cell_methods":
                     # Remove text that is inside parentheses i.e. comments
-                    file_value = re.sub(r"\(.*\)", "", file_value)
-                    table_value = re.sub(r"\(.*\)", "", table_value)
+                    file_value = re.sub(r"\(.*?\)", "", file_value)
+                    table_value = re.sub(r"\(.*?\)", "", table_value)
                     # Remove extra whitespace
                     file_value = " ".join(file_value.split())
                     table_value = " ".join(table_value.split())


### PR DESCRIPTION
Fixes #654 

The regex will now only remove multiple comment sections rather everything between them.
```
"longitude: sum (comment: basin sum [along zig-zag grid path]) depth: sum time: mean (interval: 1 month)"
```
becomes...
```
"longitude: sum  depth: sum time: mean "
```
instead of...
```
"longitude: sum "
```