### PR TITLE
Fix PrePARE for Python 3.10 builds

### DIFF
--- a/LibCV/pywrapper.py
+++ b/LibCV/pywrapper.py
@@ -270,18 +270,21 @@ def check_sourceID(table_id):
     return(ierr)
 
 
-def check_filename(table_id, var_name, calendar, timeunits, infile):
+def check_filename(table_id, var_id, calendar, timeunits, infile):
     '''
       Validate filename with timestamp for current variable and file
 
       Usage:
-        cmip6_cv.check_filename(table_id, var_id)
+        cmip6_cv.check_filename(table_id, var_id, calendar, timeunits, infile)
       Where:
         table_id is the table id returned by load_table()
-        var_name is the variable name
+        var_id is the variable id returned by setup_variable()
+        calendar is the calendar type used by the file (ex. 360_day)
+        timeunits is the time unit type used by the file (ex. days since 1850-01-01)
+        infile is the name of the file
       Return 0 on success
     '''
-    ierr = _cmip6_cv.check_filename(table_id, var_name,
+    ierr = _cmip6_cv.check_filename(table_id, var_id,
                                     calendar, timeunits, infile)
     return(ierr)
 

--- a/Src/_controlvocabulary.c
+++ b/Src/_controlvocabulary.c
@@ -17,16 +17,12 @@ static PyObject *PyCV_checkFilename(PyObject * self, PyObject * args)
     char *szInTimeCalendar;
     char *szInTimeUnits;
     char *infile;
-    int nTimeCalLen;
-    int nTimeUnitsLen;
-    int ninfile;
     int ierr;
 
     cmor_is_setup();
 
-    if (!PyArg_ParseTuple(args, "iis#s#s#", &ntable, &varid,
-                          &szInTimeCalendar, &nTimeCalLen,
-                          &szInTimeUnits, &nTimeUnitsLen, &infile, &ninfile)) {
+    if (!PyArg_ParseTuple(args, "iisss", &ntable, &varid,
+                          &szInTimeCalendar, &szInTimeUnits, &infile)) {
         return (Py_BuildValue("i", -1));
     }
 


### PR DESCRIPTION
Fixes #670 

I discovered that PrePARE was failing at the check_filename function of Python 3.10 builds.  It was due to an error occurring with a PyArg_ParseTuple call.
https://github.com/PCMDI/cmor/blob/7cb3f2a0ea22defe24019626c5260e6514678c21/Src/_controlvocabulary.c#L13-L37
The PyArg_ParseTuple call was using the argument format `iis#s#s#`, where the `s#` was meant to both get the value of a string and its length.  This was not working correctly in Python 3.10 as the string and length variables were not being initialized with the argument values.

It turned out that using the argument format of `iisss` didn't have this issue.  This means that we get the string values without their lengths.  However, the lengths of the strings were not necessary for the file checking function so the change had no impact to the rest of the function.