### PR TITLE
correct CMIP->PCMDI logo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ CMOR 3.7 documentation can be found at: http://cmor.llnl.gov
 The repository content is developed by climate and computer scientists from the Program for Climate Model Diagnosis and Intercomparison ([PCMDI][PCMDI]) at Lawrence Livermore National Laboratory ([LLNL][LLNL]), with contributions from colleagues around the world. This work is sponsored by the Regional and Global Model Analysis ([RGMA][RGMA]) program, of the Earth and Environmental Systems Sciences Division ([EESSD][EESSD]) in the Office of Biological and Environmental Research ([BER][BER]) within the [Department of Energy][DOE]'s [Office of Science][OS]. The work is performed under the auspices of the U.S. Department of Energy by Lawrence Livermore National Laboratory under Contract DE-AC52-07NA27344.
 
 <p>
-    <img src="https://pcmdi.github.io/assets/CMIP/100px-CMIP_Logo_RGB_Positive-square-96dpi.png"
+    <img src="https://pcmdi.github.io/assets/PCMDI/100px-PCMDI-Logo-NoText-square-png8.png"
          width="65"
          style="margin-right: 30px"
-         title="Couple Model Intercomparison Project International Project Office"
-         alt="Couple Model Intercomparison Project International Project Office"
+         title="Program for Climate Model Diagnosis and Intercomparison"
+         alt="Program for Climate Model Diagnosis and Intercomparison"
     >&nbsp;
     <img src="https://pcmdi.github.io/assets/DOE/480px-DOE_Seal_Color.png"
          width="65"
@@ -32,6 +32,7 @@ The repository content is developed by climate and computer scientists from the 
     >&nbsp;
     <img src="https://pcmdi.github.io/assets/LLNL/212px-LLNLiconPMS286-WHITEBACKGROUND.png"
          width="65"
+         style="margin-right: 30px"
          title="Lawrence Livermore National Laboratory"
          alt="Lawrence Livermore National Laboratory"
     >


### PR DESCRIPTION
Ref #692 

@mauzey1 this corrects the CMIP -> PCMDI logo, which I had incorrectly indexed