### PR TITLE
Remove expat link for udunits2 from configure script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ executors:
         CONDA_COMPILERS: "gcc_linux-64 gfortran_linux-64"
    macos:
       macos:
-         xcode: "13.2.1"
+         xcode: "13.4.1"
       environment:
         OS: "osx-64"
         PROJECT_DIR: "workdir/macos"

--- a/configure
+++ b/configure
@@ -4905,9 +4905,9 @@ else $as_nop
 fi
 
    if  test ${RTAG} != "none"  ; then
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2"
    else
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
     UDUNITS2FLAGS="-ludunits2"

--- a/configure.ac
+++ b/configure.ac
@@ -216,9 +216,9 @@ if [ test x${with_udunits2} != xyes ] ; then
     [UDUNITS2FLAGS=" -I${with_udunits2}/include/udunits2"],
     [UDUNITS2FLAGS=" -I${with_udunits2}/include"])
    if [ test ${RTAG} != "none" ] ; then
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2"
    else
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
     UDUNITS2FLAGS="-ludunits2"


### PR DESCRIPTION
Due to changes in a recent Linux build of udunits2, our configure script was encountering an error when trying to test for ut_parse.  The issue was caused by the removal of the library expat from udunits2.  When creating the conda environment for CMOR, expat was no longer being installed.  This lead to the configure script encountering an error when linking to the nonexistent library.

This PR removes the `-lexpat` flag from the udunits2 ut_parse test.