### PR TITLE
706 writing large volume of data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ executors:
         CONDA_COMPILERS: "gcc_linux-64 gfortran_linux-64"
    macos:
       macos:
-         xcode: "13.2.1"
+         xcode: "13.4.1"
       environment:
         OS: "osx-64"
         PROJECT_DIR: "workdir/macos"

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2344,32 +2344,32 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
 
     size_t counts[CMOR_MAX_DIMENSIONS];
     size_t counts2[CMOR_MAX_DIMENSIONS];
-    int counter[CMOR_MAX_DIMENSIONS];
-    int counter_orig[CMOR_MAX_DIMENSIONS];
-    int counter_orig2[CMOR_MAX_DIMENSIONS];
-    int counter2[CMOR_MAX_DIMENSIONS];
+    size_t counter[CMOR_MAX_DIMENSIONS];
+    size_t counter_orig[CMOR_MAX_DIMENSIONS];
+    size_t counter_orig2[CMOR_MAX_DIMENSIONS];
+    size_t counter2[CMOR_MAX_DIMENSIONS];
     size_t starts[CMOR_MAX_DIMENSIONS];
-    int nelements, loc, add, nelts;
+    size_t nelements, loc, add, nelts;
     double *data_tmp = NULL, tmp = 0., tmp2, amean;
     int *idata_tmp = NULL;
     long *ldata_tmp = NULL;
     float *fdata_tmp = NULL;
     char mtype;
-    int i, j, ierr = 0, dounits = 1;
+    size_t i, j;
+    int ierr = 0, dounits = 1;
     char msg[CMOR_MAX_STRING];
     char msg2[CMOR_MAX_STRING];
     double *tmp_vals;
     ut_unit *user_units = NULL, *cmor_units = NULL;
     cv_converter *ut_cmor_converter = NULL;
     char local_unit[CMOR_MAX_STRING];
-    int n_lower_min = 0, n_greater_max = 0;
+    size_t n_lower_min = 0, n_greater_max = 0;
     double emax, emin, first_time;
     char msg_min[CMOR_MAX_STRING];
     char msg_max[CMOR_MAX_STRING];
     extern ut_system *ut_read;
-    int tmpindex = 0;
-    int index;
-    int bb;
+    size_t tmpindex = 0;
+    size_t index;
 
     cmor_add_traceback("cmor_write_var_to_file");
     cmor_is_setup();
@@ -2423,21 +2423,20 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
     counter[avar->ndims] = 1;   /* dummy */
     counter_orig[avar->ndims] = 1;      /*dummy */
 
-    for (i = avar->ndims - 1; i >= 0; i--) {
+    for (i = avar->ndims; i > 0; i--) {
 /* -------------------------------------------------------------------- */
 /*      we need to do this for the order in which we will write and     */
 /*      the order the user defined its variable                         */
 /* -------------------------------------------------------------------- */
-
-        if (cmor_axes[avar->axes_ids[i]].axis != 'T')
-            counter[i] = cmor_axes[avar->axes_ids[i]].length * counter[i + 1];
+        if (cmor_axes[avar->axes_ids[i - 1]].axis != 'T')
+            counter[i - 1] = cmor_axes[avar->axes_ids[i - 1]].length * counter[i];
         else
-            counter[i] = counts[0] * counter[i + 1];
-        if (cmor_axes[avar->original_order[i]].axis != 'T')
-            counter_orig[i] = cmor_axes[avar->original_order[i]].length
-              * counter_orig[i + 1];
+            counter[i - 1] = counts[0] * counter[i];
+        if (cmor_axes[avar->original_order[i - 1]].axis != 'T')
+            counter_orig[i - 1] = cmor_axes[avar->original_order[i - 1]].length
+              * counter_orig[i];
         else
-            counter_orig[i] = counts[0] * counter_orig[i + 1];
+            counter_orig[i - 1] = counts[0] * counter_orig[i];
     }
 /* -------------------------------------------------------------------- */
 /*       Now we need to map, i.e going ahead by 2 elements of final     */
@@ -2462,7 +2461,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
         idata_tmp = malloc(sizeof(int) * nelements);
         if (idata_tmp == NULL) {
             snprintf(msg, CMOR_MAX_STRING,
-                     "cannot allocate memory for %i int tmp elts var '%s' "
+                     "cannot allocate memory for %lu int tmp elts var '%s' "
                      "(table: %s)",
                      nelements, avar->id,
                      cmor_tables[avar->ref_table_id].szTable_id);
@@ -2474,7 +2473,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
         ldata_tmp = malloc(sizeof(long) * nelements);
         if (ldata_tmp == NULL) {
             snprintf(msg, CMOR_MAX_STRING,
-                     "cannot allocate memory for %i long tmp elts var '%s' "
+                     "cannot allocate memory for %lu long tmp elts var '%s' "
                      "(table: %s)",
                      nelements, avar->id,
                      cmor_tables[avar->ref_table_id].szTable_id);
@@ -2486,7 +2485,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
         data_tmp = malloc(sizeof(double) * nelements);
         if (data_tmp == NULL) {
             snprintf(msg, CMOR_MAX_STRING,
-                     "cannot allocate memory for %i double tmp elts var '%s' "
+                     "cannot allocate memory for %lu double tmp elts var '%s' "
                      "(table: %s)",
                      nelements, avar->id,
                      cmor_tables[avar->ref_table_id].szTable_id);
@@ -2498,7 +2497,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
         fdata_tmp = malloc(sizeof(float) * nelements);
         if (fdata_tmp == NULL) {
             snprintf(msg, CMOR_MAX_STRING,
-                     "cannot allocate memory for %i float tmp elts var '%s' "
+                     "cannot allocate memory for %lu float tmp elts var '%s' "
                      "(table: %s)",
                      nelements, avar->id,
                      cmor_tables[avar->ref_table_id].szTable_id);
@@ -2575,7 +2574,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
 /*      puts the result in counter2                                     */
 /* -------------------------------------------------------------------- */
         for (j = 0; j < avar->ndims; j++) {
-            counter2[j] = (int)loc / (int)counter[j + 1];
+            counter2[j] = (size_t)loc / (size_t)counter[j + 1];
 
 /* -------------------------------------------------------------------- */
 /*      this is the reverse part doing it this way to avoid if test     */
@@ -2595,14 +2594,14 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                 add = counter2[j] * pAxis->revert + (pAxis->length - 1) *
                   (1 - pAxis->revert) / 2;
 
-                loc = loc + (int)fmod(add + pAxis->offset, pAxis->length)
+                loc = loc + (size_t)fmod(add + pAxis->offset, pAxis->length)
                   * counter_orig2[j];
 
             } else {
 
                 add = counter2[j] * pAxis->revert + (counts[0] - 1) *
                   (1 - pAxis->revert) / 2;
-                loc = loc + (int)fmod(add + pAxis->offset, counts[0])
+                loc = loc + (size_t)fmod(add + pAxis->offset, counts[0])
                   * counter_orig2[j];
             }
 
@@ -2677,12 +2676,12 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                         cmor_axis_t *pAxis;
                         pAxis = &cmor_axes[avar->axes_ids[j]];
                         if (pAxis->values != NULL) {
-                            snprintf(msg2, CMOR_MAX_STRING, " %s: %i/%.5g",
+                            snprintf(msg2, CMOR_MAX_STRING, " %s: %lu/%.5g",
                                      pAxis->id, counter2[j],
                                      pAxis->values[counter2[j]]);
 
                         } else {
-                            snprintf(msg2, CMOR_MAX_STRING, " %s: %i/%.5g",
+                            snprintf(msg2, CMOR_MAX_STRING, " %s: %lu/%.5g",
                                      pAxis->id, counter2[j],
                                      time_vals[counter2[j]]);
                         }
@@ -2711,11 +2710,11 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                         pAxis = &cmor_axes[avar->axes_ids[j]];
 
                         if (pAxis->values != NULL) {
-                            snprintf(msg2, CMOR_MAX_STRING, " %s: %i/%.5g",
+                            snprintf(msg2, CMOR_MAX_STRING, " %s: %lu/%.5g",
                                      pAxis->id, counter2[j],
                                      pAxis->values[counter2[j]]);
                         } else {
-                            snprintf(msg2, CMOR_MAX_STRING, " %s: %i/%.5g",
+                            snprintf(msg2, CMOR_MAX_STRING, " %s: %lu/%.5g",
                                      pAxis->id, counter2[j],
                                      time_vals[counter2[j]]);
                         }

--- a/configure
+++ b/configure
@@ -4905,9 +4905,9 @@ else $as_nop
 fi
 
    if  test ${RTAG} != "none"  ; then
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2"
    else
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
     UDUNITS2FLAGS="-ludunits2"

--- a/configure.ac
+++ b/configure.ac
@@ -216,9 +216,9 @@ if [ test x${with_udunits2} != xyes ] ; then
     [UDUNITS2FLAGS=" -I${with_udunits2}/include/udunits2"],
     [UDUNITS2FLAGS=" -I${with_udunits2}/include"])
    if [ test ${RTAG} != "none" ] ; then
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib  ${RTAG}${with_udunits2}/lib -ludunits2"
    else
-     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2 -lexpat"
+     UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
     UDUNITS2FLAGS="-ludunits2"


### PR DESCRIPTION
Resolves #706 

This PR will replace the use of `int` with `size_t` in the function `cmor_write_var_to_file` when calculating the number of elements in an array.  This will allow `cmor_write` to write data arrays with more than 2^31-1 elements.