### PR TITLE
Speed up rerender for nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ aliases:
        export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
        python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
-        --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
+        --do_rerender --conda_env build_env --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
        
   - &conda_build
     name: conda_build
@@ -60,7 +60,7 @@ aliases:
        export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
        python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build \
-        --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
+        --conda_env build_env --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
 
   - &run_cmor_tests
     name: run_cmor_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ aliases:
        export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
        python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
-        --do_rerender --conda_env build_env --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
+        --do_rerender --conda_env rerender_env --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
        
   - &conda_build
     name: conda_build


### PR DESCRIPTION
The rerendering step for the nightly builds have been really slow.  They have been taking up to 30 minutes to complete.  The issue was caused by trying to install the conda build packages into the base miniconda environment.  Installing to the base environment made conda process package conflicts, which can take a long time and will sometimes cause the build to fail if it takes too long.

The solution was to have the rerender step create another conda environment with the conda build packages.  This has reduced the time of the rerender step from around 30 minutes to around 1 minute.