### PR TITLE
Make further_info_url attribute only be used if required by CV or requested by user

### DIFF
--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -2794,10 +2794,10 @@ int cmor_setDefaultGblAttr(int ref_table_id)
 
         if(cmor_has_cur_dataset_attribute(CV_value->key) != 0){
             if(CV_value->szValue[0] != '\0'){
-                if(strncmp(CV_value->key, GLOBAL_ATT_FURTHERINFOURL, CMOR_MAX_STRING) == 0){
+                ierr |= cmor_set_cur_dataset_attribute_internal(CV_value->key, CV_value->szValue, 0);
+                if(strncmp(CV_value->key, GLOBAL_ATT_FURTHERINFOURL, CMOR_MAX_STRING) == 0
+                     && cmor_current_dataset.furtherinfourl[0] == '\0'){
                     ierr |= cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_FURTHERINFOURLTMPL, CV_value->szValue, 0);
-                } else {
-                    ierr |= cmor_set_cur_dataset_attribute_internal(CV_value->key, CV_value->szValue, 0);
                 }
             } else if(CV_value->anElements == 1 && isRequired == 1){
                 ierr |= cmor_set_cur_dataset_attribute_internal(CV_value->key, CV_value->aszValue[0], 0);

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -371,6 +371,13 @@ int cmor_CV_checkFurtherInfoURL(int nVarRefTblID)
     cmor_add_traceback("_CV_checkFurtherInfoURL");
 
 /* -------------------------------------------------------------------- */
+/* If the template is an emtpy string, then skip this check.            */
+/* -------------------------------------------------------------------- */
+    if (cmor_current_dataset.furtherinfourl[0] == '\0') {
+        return (0);
+    }
+
+/* -------------------------------------------------------------------- */
 /* Retrieve default Further URL info                                    */
 /* -------------------------------------------------------------------- */
     strncpy(szFurtherInfoURLTemplate, cmor_current_dataset.furtherinfourl,
@@ -391,8 +398,11 @@ int cmor_CV_checkFurtherInfoURL(int nVarRefTblID)
     }
 
     if (strcmp(szToken, cmor_current_dataset.furtherinfourl) == 0) {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_FURTHERINFOURL,
+                                                cmor_current_dataset.furtherinfourl, 0);
         return (0);
     }
+
     strncpy(szFurtherInfoURLTemplate, cmor_current_dataset.furtherinfourl,
             CMOR_MAX_STRING);
 /* -------------------------------------------------------------------- */

--- a/Test/CMIP6Plus_user_input.json
+++ b/Test/CMIP6Plus_user_input.json
@@ -33,7 +33,6 @@
     "_controlled_vocabulary_file": "TestTables/CMIP6Plus_CV.json",
     "_AXIS_ENTRY_FILE": "mip-cmor-tables/Auxillary_files/MIP_coordinate.json",
     "_FORMULA_VAR_FILE": "mip-cmor-tables/Auxillary_files/MIP_formula_terms.json",
-    "further_info_url": "https://furtherinfo.es-doc.org/",
     "mo_runid": "u-be509",
     "branch_time_in_parent": 59400.0,
     "branch_time_in_child": 59400.0

--- a/Test/CMOR_input_example_badfurtherinfourl.json
+++ b/Test/CMOR_input_example_badfurtherinfourl.json
@@ -64,7 +64,7 @@
  
     "mip_era":                "CMIP6",
     "parent_mip_era":         "CMIP6",
-    "further_info_url":       "",
+    "further_info_url":       "bad_url",
  
     "tracking_prefix":        "hdl:21.14100",
     "_history_template":       "%s ;rewrote data to be consistent with <activity_id> for variable <variable_id> found in table <table_id>.",

--- a/Test/test_cmor_CMIP6Plus.py
+++ b/Test/test_cmor_CMIP6Plus.py
@@ -47,7 +47,9 @@ class TestCMIP6Plus(unittest.TestCase):
         self.assertEqual(
             cmor.write(ivar, data, ntimes_passed=ntimes_passed),
             0)
-
+        
+        self.assertFalse(cmor.has_cur_dataset_attribute('further_info_url'))
+        
         realms = cmor.get_cur_dataset_attribute('realm')
         self.assertEqual(realms, "ocean seaIce")
 

--- a/Test/test_python_CMIP6_CV_badfurtherinfourl.py
+++ b/Test/test_python_CMIP6_CV_badfurtherinfourl.py
@@ -59,8 +59,7 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         # ------------------------------------------
         # Check error after signal handler is back
         # ------------------------------------------
-        self.assertCV("The further info URL value of \"\" is invalid.")
-
+        self.assertCV("Error: The attribute \"further_info_url\" could not be validated.")
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
This PR will make CMOR only add a `further_info_url` attribute to the file if it is either required by the CV, or set in the user input file.  If `further_info_url` is in the `required_global_attributes` section of the CV, it will require CMOR to add that attribute to the file.

The `further_info_url` attribute value provided by the user in the input file is a template that will be used by CMOR to generate a URL.  If the user doesn't provide a template value when it is required, then CMOR will use its built-in default template for the URL.  If the CV file provides a value for `further_info_url` in the `source_id` entry, then it will be used as a value for the file's attribute unless `further_info_url` is set in the user input.