### PR TITLE
Remove the use of the conda-recipe repo in the CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ aliases:
     command: |
        source $BASH_ENV
        if [[ $OS == 'osx-64' ]]; then
-       curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+          curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
        else
-       curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+          curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
        fi
        bash miniconda.sh -b -p $WORKDIR/miniconda
        
@@ -37,12 +37,27 @@ aliases:
        conda activate base
        conda config --set anaconda_upload no
 
-       git clone -b master https://github.com/CDAT/conda-recipes $WORKDIR/conda-recipes
-       export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=$WORKDIR/miniconda/bin/activate
+       git clone -b main https://github.com/conda-forge/cmor-feedstock $WORKDIR/cmor-feedstock
+       export SRC_META_YAML=$WORKDIR/cmor-feedstock/recipe/meta.yaml.SRC
+       export DST_META_YAML=$WORKDIR/cmor-feedstock/recipe/meta.yaml
+       mv $DST_META_YAML $SRC_META_YAML
 
-       python $BUILD_SCRIPT -w $WORKDIR -l $VERSION -B 0 -p $PKG_NAME -r $PKG_NAME -b $CIRCLE_BRANCH \
-        --do_rerender --conda_env base --ignore_conda_missmatch --conda_activate $ACTIVATE --organization PCMDI
+       export GIT_REV=$(git rev-parse --short HEAD)
+
+       python rebuild_meta_yaml.py \
+        --package_name $PKG_NAME \
+        --version $VERSION \
+        --organization PCMDI \
+        --repo_name $PKG_NAME \
+        --branch $CIRCLE_BRANCH \
+        --git_rev $GIT_REV \
+        --build 0 \
+        --src_meta_yaml $SRC_META_YAML \
+        --dst_meta_yaml $DST_META_YAML
+
+       conda install -c conda-forge conda-smithy
+       cd $WORKDIR/cmor-feedstock
+       conda smithy rerender
        
   - &conda_build
     name: conda_build
@@ -54,13 +69,18 @@ aliases:
 
        export ARTIFACT_DIR=`pwd`/artifacts/artifacts.$OS.py_$PYTHON_VERSION
        mkdir -p $ARTIFACT_DIR
-       
-       export CONDA_BUILD_EXTRA=" --copy_conda_package $ARTIFACT_DIR/"
-       export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py
-       export ACTIVATE=$WORKDIR/miniconda/bin/activate
 
-       python $BUILD_SCRIPT -w $WORKDIR -p $PKG_NAME --build_version $PYTHON_VERSION --do_build \
-        --conda_env base --extra_channels conda-forge --conda_activate $ACTIVATE $CONDA_BUILD_EXTRA
+       if [[ $OS == 'osx-64' ]]; then
+          export OS_NAME="osx_64"
+       else
+          export OS_NAME="linux_64"
+       fi
+
+       for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
+          conda build -c conda-forge -m $i $WORKDIR/cmor-feedstock/recipe/
+          OUTPUT=$(conda build --output -m $i $WORKDIR/cmor-feedstock/recipe/)
+          cp $OUTPUT $ARTIFACT_DIR
+       done
 
   - &run_cmor_tests
     name: run_cmor_tests
@@ -68,7 +88,6 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       export UVCDAT_ANONYMOUS_LOG=False
        set +e
        conda create -y -n test_py$PYTHON_VERSION --use-local $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
        conda activate test_py$PYTHON_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ aliases:
        conda config --set anaconda_upload no
        conda activate smithy_env
 
+       export BUILD_DIR=`pwd`/cmor_conda_pkgs
+       mkdir -p $BUILD_DIR
+
        export ARTIFACT_DIR=`pwd`/artifacts/$OS
        mkdir -p $ARTIFACT_DIR
 
@@ -79,9 +82,8 @@ aliases:
        fi
 
        for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
-          conda build -c conda-forge -m $i $WORKDIR/cmor-feedstock/recipe/
-          OUTPUT=$(conda build -c conda-forge --output -m $i $WORKDIR/cmor-feedstock/recipe/)
-          cp $OUTPUT $ARTIFACT_DIR
+          conda build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
+          cp $BUILD_DIR/$OS/$PKG_NAME-$VERSION*.tar.bz2 $ARTIFACT_DIR
        done
 
   - &run_cmor_tests
@@ -89,9 +91,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate smithy_env
-       export CMOR_CHANNEL=`pwd`/artifacts/
-       conda index $CMOR_CHANNEL
+       conda activate base
+       export CMOR_CHANNEL=`pwd`/cmor_conda_pkgs/
        conda search -c file://$CMOR_CHANNEL --override-channels
        set +e
        conda create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        set +e
-       export CMOR_CHANNEL=$WORKDIR/artifacts/
+       export CMOR_CHANNEL=`pwd`/artifacts/
        conda index $CMOR_CHANNEL
        conda search -c file://$CMOR_CHANNEL --override-channels
        conda create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ aliases:
 
        for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
           conda build -c conda-forge -m $i $WORKDIR/cmor-feedstock/recipe/
-          OUTPUT=$(conda build --output -m $i $WORKDIR/cmor-feedstock/recipe/)
+          OUTPUT=$(conda build -c conda-forge --output -m $i $WORKDIR/cmor-feedstock/recipe/)
           cp $OUTPUT $ARTIFACT_DIR
        done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,11 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       set +e
+       conda activate smithy_env
        export CMOR_CHANNEL=`pwd`/artifacts/
        conda index $CMOR_CHANNEL
        conda search -c file://$CMOR_CHANNEL --override-channels
+       set +e
        conda create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
        conda activate test_py$PYTHON_VERSION
        set -e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,8 @@ aliases:
         --src_meta_yaml $SRC_META_YAML \
         --dst_meta_yaml $DST_META_YAML
 
-       conda install -c conda-forge conda-smithy
+       conda create -y -n smithy_env -c conda-forge conda-smithy
+       conda activate smithy_env
        cd $WORKDIR/cmor-feedstock
        conda smithy rerender
        
@@ -66,8 +67,9 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        conda config --set anaconda_upload no
+       conda activate smithy_env
 
-       export ARTIFACT_DIR=`pwd`/artifacts/artifacts.$OS.py_$PYTHON_VERSION
+       export ARTIFACT_DIR=`pwd`/artifacts/$OS
        mkdir -p $ARTIFACT_DIR
 
        if [[ $OS == 'osx-64' ]]; then
@@ -89,7 +91,10 @@ aliases:
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        set +e
-       conda create -y -n test_py$PYTHON_VERSION --use-local $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
+       export CMOR_CHANNEL=$WORKDIR/artifacts/
+       conda index $CMOR_CHANNEL
+       conda search -c file://$CMOR_CHANNEL --override-channels
+       conda create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
        conda activate test_py$PYTHON_VERSION
        set -e
        ./configure --prefix=$CONDA_PREFIX --with-python --with-uuid=$CONDA_PREFIX --with-json-c=$CONDA_PREFIX --with-udunits2=$CONDA_PREFIX --with-netcdf=$CONDA_PREFIX  --enable-verbose-test

--- a/rebuild_meta_yaml.py
+++ b/rebuild_meta_yaml.py
@@ -1,0 +1,71 @@
+import os
+import re
+import sys
+import time
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='Rebuild meta.yaml from conda-forge feedstock',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument("-p", "--package_name",
+                    help="Package name to build")
+parser.add_argument("-o", "--organization",
+                    help="github organization name", default="PCMDI")
+parser.add_argument("-r", "--repo_name",
+                    help="repo name to build", default="cmor")
+parser.add_argument("-b", "--branch", default='main', help="branch to build")
+parser.add_argument("-v", "--version",
+                    help="version are we building for")
+parser.add_argument("-g", "--git_rev",
+                    help="Latest commit")
+parser.add_argument("-B", "--build", default="0",
+                    help="build number, this should be 0 for nightly")
+parser.add_argument("--local_repo", help="Path to local project repository")
+parser.add_argument("--src_meta_yaml", help="Path to source meta.yaml")
+parser.add_argument("--dst_meta_yaml", help="Path to destination meta.yaml")
+
+args = parser.parse_args(sys.argv[1:])
+
+print("Rebuilding meta.yaml with the following...")
+for k, v in vars(args).items():
+    print(f"{k}: {v}")
+
+repo_url = f"https://github.com/{args.organization}/{args.repo_name}.git"
+
+package_time = time.strftime("%Y.%m.%d.%H.%M", time.localtime())
+version = f"{args.version}.{package_time}.{args.git_rev}"
+
+with open(args.src_meta_yaml, "r") as src, \
+        open(args.dst_meta_yaml, "w") as dst:
+    start_copy = True
+    lines = src.readlines()
+    for line in lines:
+        match_obj = re.match("package:", line)
+        if match_obj:
+            start_copy = False
+            dst.write("package:\n")
+            dst.write(f"  name: {args.package_name}\n")
+            dst.write(f"  version: {version}\n\n")
+
+            dst.write("source:\n")
+            if args.local_repo is None:
+                dst.write(f"  git_rev: {args.branch}\n")
+                dst.write(f"  git_url: {repo_url}\n\n")
+            else:
+                dst.write(f"  path: {args.local_repo}\n\n")
+
+            continue
+
+        match_obj = re.match("build:", line)
+        if match_obj:
+            start_copy = True
+
+        match_build_number = re.match(r"\s+number:", line)
+        if match_build_number:
+            dst.write(f"  number: {args.build}\n")
+            continue
+        if start_copy:
+            dst.write(line)
+        else:
+            continue


### PR DESCRIPTION
Replace the use of [CDAT/conda-recipes](https://github.com/CDAT/conda-recipes/tree/master/build_tools) for nightly builds of CMOR with tools in this repo.  The [cmor-feedstock repo](https://github.com/conda-forge/cmor-feedstock) is cloned, a script edits the meta.yaml of the feedstock, and then conda-smithy is used to rerender the feedstock and build the conda packages.