### PR TITLE
Remove default value for attribute 'realm'

### DIFF
--- a/Src/cmor_tables.c
+++ b/Src/cmor_tables.c
@@ -83,7 +83,7 @@ void cmor_init_table(cmor_table_t * table, int id)
     table->cmor_version = 3.0;
     table->mip_era[0] = '\0';
     table->szTable_id[0] = '\0';
-    strcpy(table->realm, "REALM");
+    table->realm[0] = '\0';
     table->date[0] = '\0';
     table->missing_value = 1.0e+20;
     table->int_missing_value = 2147483647;


### PR DESCRIPTION
Closes #736 

This will remove the setting of the `realm` attribute to the default value of `REALM`.  `realm` will still be set to the `modeling_realm` attribute's value from the variable's table even if `realm` is not a required attribute in the CV.