### PR TITLE
Migrating CI to miniforge and mamba

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ aliases:
        mamba create -y -n smithy_env -c conda-forge conda-smithy
        mamba activate smithy_env
        cd $WORKDIR/cmor-feedstock
-       mamba smithy rerender
+       mamba run conda smithy rerender
        
   - &conda_build
     name: conda_build
@@ -82,7 +82,7 @@ aliases:
        fi
 
        for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
-          mamba build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
+          mamba run conda build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
           cp $BUILD_DIR/$OS/$PKG_NAME-$VERSION*.tar.bz2 $ARTIFACT_DIR
        done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ aliases:
     name: conda_rerender
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no
 
@@ -64,7 +64,7 @@ aliases:
     name: conda_build
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no
        mamba activate smithy_env
@@ -90,7 +90,7 @@ aliases:
     name: run_cmor_tests
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        export CMOR_CHANNEL=`pwd`/cmor_conda_pkgs/
        mamba search -c file://$CMOR_CHANNEL --override-channels
@@ -105,7 +105,7 @@ aliases:
     name: conda_upload
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no
        mamba install -n base -c conda-forge anaconda-client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ aliases:
     name: conda_rerender
     command: |
        source $BASH_ENV
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no
@@ -64,6 +65,7 @@ aliases:
     name: conda_build
     command: |
        source $BASH_ENV
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no
@@ -90,6 +92,7 @@ aliases:
     name: run_cmor_tests
     command: |
        source $BASH_ENV
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        export CMOR_CHANNEL=`pwd`/cmor_conda_pkgs/
@@ -105,6 +108,7 @@ aliases:
     name: conda_upload
     command: |
        source $BASH_ENV
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba config --set anaconda_upload no

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ aliases:
 
        for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
           mamba run conda build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
-          cp $BUILD_DIR/$OS/$PKG_NAME-$VERSION*.tar.bz2 $ARTIFACT_DIR
+          cp $BUILD_DIR/$OS/$PKG_NAME-$VERSION*.conda $ARTIFACT_DIR
        done
 
   - &run_cmor_tests
@@ -111,7 +111,7 @@ aliases:
        mamba activate base
        mamba install -n base -c conda-forge anaconda-client
        export ARTIFACT_DIR=`pwd`/artifacts
-       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force
+       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.conda --force
 
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ aliases:
     command: |
        source $BASH_ENV
        if [[ $OS == 'osx-64' ]]; then
-          wget -O miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh -o miniforge3.sh
        else
-          curl -fsSLo miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
+          curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -o miniforge3.sh
        fi
        bash miniforge3.sh -b -p $WORKDIR/miniforge3
        
@@ -36,7 +36,6 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
-       mamba config --set anaconda_upload no
 
        git clone -b main https://github.com/conda-forge/cmor-feedstock $WORKDIR/cmor-feedstock
        export SRC_META_YAML=$WORKDIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -68,7 +67,6 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
-       mamba config --set anaconda_upload no
        mamba activate smithy_env
 
        export BUILD_DIR=`pwd`/cmor_conda_pkgs
@@ -111,7 +109,6 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
-       mamba config --set anaconda_upload no
        mamba install -n base -c conda-forge anaconda-client
        export ARTIFACT_DIR=`pwd`/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,24 +18,24 @@ aliases:
       git submodule init
       git submodule update
 
-  - &setup_miniconda
-    name: setup_miniconda
+  - &setup_miniforge3
+    name: setup_miniforge3
     command: |
        source $BASH_ENV
        if [[ $OS == 'osx-64' ]]; then
-          curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
+          wget -O miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
        else
-          curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
+          curl -fsSLo miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$(uname -m).sh"
        fi
-       bash miniconda.sh -b -p $WORKDIR/miniconda
+       bash miniforge3.sh -b -p $WORKDIR/miniforge3
        
   - &conda_rerender
     name: conda_rerender
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       conda config --set anaconda_upload no
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       mamba activate base
+       mamba config --set anaconda_upload no
 
        git clone -b main https://github.com/conda-forge/cmor-feedstock $WORKDIR/cmor-feedstock
        export SRC_META_YAML=$WORKDIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -55,19 +55,19 @@ aliases:
         --src_meta_yaml $SRC_META_YAML \
         --dst_meta_yaml $DST_META_YAML
 
-       conda create -y -n smithy_env -c conda-forge conda-smithy
-       conda activate smithy_env
+       mamba create -y -n smithy_env -c conda-forge conda-smithy
+       mamba activate smithy_env
        cd $WORKDIR/cmor-feedstock
-       conda smithy rerender
+       mamba smithy rerender
        
   - &conda_build
     name: conda_build
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       conda config --set anaconda_upload no
-       conda activate smithy_env
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       mamba activate base
+       mamba config --set anaconda_upload no
+       mamba activate smithy_env
 
        export BUILD_DIR=`pwd`/cmor_conda_pkgs
        mkdir -p $BUILD_DIR
@@ -82,7 +82,7 @@ aliases:
        fi
 
        for i in ${WORKDIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
-          conda build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
+          mamba build -c conda-forge --output-folder $BUILD_DIR -m $i $WORKDIR/cmor-feedstock/recipe/
           cp $BUILD_DIR/$OS/$PKG_NAME-$VERSION*.tar.bz2 $ARTIFACT_DIR
        done
 
@@ -90,13 +90,13 @@ aliases:
     name: run_cmor_tests
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       mamba activate base
        export CMOR_CHANNEL=`pwd`/cmor_conda_pkgs/
-       conda search -c file://$CMOR_CHANNEL --override-channels
+       mamba search -c file://$CMOR_CHANNEL --override-channels
        set +e
-       conda create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
-       conda activate test_py$PYTHON_VERSION
+       mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
+       mamba activate test_py$PYTHON_VERSION
        set -e
        ./configure --prefix=$CONDA_PREFIX --with-python --with-uuid=$CONDA_PREFIX --with-json-c=$CONDA_PREFIX --with-udunits2=$CONDA_PREFIX --with-netcdf=$CONDA_PREFIX  --enable-verbose-test
        make test -o cmor -o python
@@ -105,10 +105,10 @@ aliases:
     name: conda_upload
     command: |
        source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       conda config --set anaconda_upload no
-       conda install -n base anaconda-client
+       source $WORKDIR/miniforge3/etc/profile.d/conda.sh
+       mamba activate base
+       mamba config --set anaconda_upload no
+       mamba install -n base -c conda-forge anaconda-client
        export ARTIFACT_DIR=`pwd`/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force
 
@@ -148,7 +148,7 @@ jobs:
          - attach_workspace:
             at: .
          - run: *setup_env
-         - run: *setup_miniconda
+         - run: *setup_miniforge3
          - run: *conda_rerender
          - run: *conda_build
          - run: *pull_submodules
@@ -171,7 +171,7 @@ jobs:
          - attach_workspace:
               at: .
          - run: *setup_env
-         - run: *setup_miniconda
+         - run: *setup_miniforge3
          - run: *conda_upload
 
    testing_upload:
@@ -187,7 +187,7 @@ jobs:
          - attach_workspace:
               at: .
          - run: *setup_env
-         - run: *setup_miniconda
+         - run: *setup_miniforge3
          - run: *conda_upload
 
 workflows:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup project directory
         run: mkdir -p $PROJECT_DIR
 
-      - name: Setup Miniconda
+      - name: Setup Miniforge
         run: |
           curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
           bash miniforge3.sh -b -p $PROJECT_DIR/miniforge3

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -93,7 +93,7 @@ jobs:
           mamba create -y -n smithy_env -c conda-forge conda-smithy
           mamba activate smithy_env
           cd $PROJECT_DIR/cmor-feedstock
-          mamba smithy rerender
+          mamba run conda smithy rerender
           ls -lh .ci_support/
 
       - name: Conda Build
@@ -110,7 +110,7 @@ jobs:
           mkdir -p $ARTIFACT_DIR
 
           for i in ${PROJECT_DIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
-            mamba build -c conda-forge --output-folder $BUILD_DIR -m $i $PROJECT_DIR/cmor-feedstock/recipe/
+            mamba run conda build -c conda-forge --output-folder $BUILD_DIR -m $i $PROJECT_DIR/cmor-feedstock/recipe/
             ls -lh $BUILD_DIR
             cp $BUILD_DIR/$OS/$PACKAGE_NAME-$PACKAGE_VERSION*.tar.bz2 $ARTIFACT_DIR
           done

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -112,7 +112,7 @@ jobs:
           for i in ${PROJECT_DIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
             mamba run conda build -c conda-forge --output-folder $BUILD_DIR -m $i $PROJECT_DIR/cmor-feedstock/recipe/
             ls -lh $BUILD_DIR
-            cp $BUILD_DIR/$OS/$PACKAGE_NAME-$PACKAGE_VERSION*.tar.bz2 $ARTIFACT_DIR
+            cp $BUILD_DIR/$OS/$PACKAGE_NAME-$PACKAGE_VERSION*.conda $ARTIFACT_DIR
           done
 
       - name: Run Tests
@@ -140,5 +140,5 @@ jobs:
           mamba activate base
           mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts
-          anaconda -t $CONDA_UPLOAD_TOKEN upload -u $CONDA_USER -l $CONDA_LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force
+          anaconda -t $CONDA_UPLOAD_TOKEN upload -u $CONDA_USER -l $CONDA_LABEL $ARTIFACT_DIR/*/*.conda --force
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,14 +17,14 @@ jobs:
           - RUNNER_OS: 'macos-14'
             OS: osx-arm64
             OS_NAME: osx_arm64
-            MINICONDA_INSTALLER_URL: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+            MINIFORGE_INSTALLER_URL: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
             C_COMPILER: clang_osx-arm64 
             FORTRAN_COMPILER: gfortran_osx-arm64
             PROJECT_DIR: workdir/macos_arm64
           - RUNNER_OS: 'macos-13'
             OS: osx-64
             OS_NAME: osx_64
-            MINICONDA_INSTALLER_URL: https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            MINIFORGE_INSTALLER_URL: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh
             C_COMPILER: clang_osx-64 
             FORTRAN_COMPILER: gfortran_osx-64
             PROJECT_DIR: workdir/macos_64
@@ -39,7 +39,7 @@ jobs:
       CONDA_LABEL: nightly
       OS: ${{ matrix.runner.OS }}
       OS_NAME: ${{ matrix.runner.OS_NAME }}
-      MINICONDA_INSTALLER_URL: ${{ matrix.runner.MINICONDA_INSTALLER_URL }}
+      MINIFORGE_INSTALLER_URL: ${{ matrix.runner.MINIFORGE_INSTALLER_URL }}
       C_COMPILER: ${{ matrix.runner.C_COMPILER }} 
       FORTRAN_COMPILER: ${{ matrix.runner.FORTRAN_COMPILER }} 
       PROJECT_DIR: ${{ matrix.runner.PROJECT_DIR }}
@@ -57,17 +57,17 @@ jobs:
 
       - name: Setup Miniconda
         run: |
-          curl -L $MINICONDA_INSTALLER_URL -o miniconda.sh
-          bash miniconda.sh -b -p $PROJECT_DIR/miniconda
-          source $PROJECT_DIR/miniconda/etc/profile.d/conda.sh
-          conda activate base
-          conda config --set anaconda_upload no
+          curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
+          bash miniforge3.sh -b -p $PROJECT_DIR/miniforge3
+          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          mamba activate base
+          mamba config --set anaconda_upload no
 
       - name: Conda Rerender
         run: |
-          source $PROJECT_DIR/miniconda/etc/profile.d/conda.sh
-          conda activate base
-          conda config --set anaconda_upload no
+          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          mamba activate base
+          mamba config --set anaconda_upload no
 
           git clone -b main https://github.com/conda-forge/cmor-feedstock $PROJECT_DIR/cmor-feedstock
           export SRC_META_YAML=`pwd`/$PROJECT_DIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -90,18 +90,18 @@ jobs:
             --src_meta_yaml $SRC_META_YAML \
             --dst_meta_yaml $DST_META_YAML
 
-          conda create -y -n smithy_env -c conda-forge conda-smithy
-          conda activate smithy_env
+          mamba create -y -n smithy_env -c conda-forge conda-smithy
+          mamba activate smithy_env
           cd $PROJECT_DIR/cmor-feedstock
-          conda smithy rerender
+          mamba smithy rerender
           ls -lh .ci_support/
 
       - name: Conda Build
         run: |
-          source $PROJECT_DIR/miniconda/etc/profile.d/conda.sh
-          conda activate base
-          conda config --set anaconda_upload no
-          conda activate smithy_env
+          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          mamba activate base
+          mamba config --set anaconda_upload no
+          mamba activate smithy_env
 
           export BUILD_DIR=`pwd`/cmor_conda_pkgs
           mkdir -p $BUILD_DIR
@@ -110,22 +110,22 @@ jobs:
           mkdir -p $ARTIFACT_DIR
 
           for i in ${PROJECT_DIR}'/cmor-feedstock/.ci_support/'${OS_NAME}'_*python'${PYTHON_VERSION}'*.yaml'; do
-            conda build -c conda-forge --output-folder $BUILD_DIR -m $i $PROJECT_DIR/cmor-feedstock/recipe/
+            mamba build -c conda-forge --output-folder $BUILD_DIR -m $i $PROJECT_DIR/cmor-feedstock/recipe/
             ls -lh $BUILD_DIR
             cp $BUILD_DIR/$OS/$PACKAGE_NAME-$PACKAGE_VERSION*.tar.bz2 $ARTIFACT_DIR
           done
 
       - name: Run Tests
         run: |
-          source $PROJECT_DIR/miniconda/etc/profile.d/conda.sh
-          conda activate base
-          conda config --set anaconda_upload no
+          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          mamba activate base
+          mamba config --set anaconda_upload no
 
           export CMOR_CHANNEL=file://`pwd`/cmor_conda_pkgs/
-          conda search -c $CMOR_CHANNEL --override-channels
+          mamba search -c $CMOR_CHANNEL --override-channels
 
-          conda create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL python=$PYTHON_VERSION $PACKAGE_NAME=$PACKAGE_VERSION $C_COMPILER $FORTRAN_COMPILER
-          conda activate test_py$PYTHON_VERSION
+          mamba create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL python=$PYTHON_VERSION $PACKAGE_NAME=$PACKAGE_VERSION $C_COMPILER $FORTRAN_COMPILER
+          mamba activate test_py$PYTHON_VERSION
 
           ./configure --prefix=$CONDA_PREFIX --with-python --with-uuid=$CONDA_PREFIX --with-json-c=$CONDA_PREFIX --with-udunits2=$CONDA_PREFIX --with-netcdf=$CONDA_PREFIX  --enable-verbose-test
           make test -o cmor -o python
@@ -135,10 +135,10 @@ jobs:
           CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          source $PROJECT_DIR/miniconda/etc/profile.d/conda.sh
-          conda activate base
-          conda config --set anaconda_upload no
-          conda install -n base anaconda-client
+          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          mamba activate base
+          mamba config --set anaconda_upload no
+          mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts
           anaconda -t $CONDA_UPLOAD_TOKEN upload -u $CONDA_USER -l $CONDA_LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -62,14 +62,12 @@ jobs:
           source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
-          mamba config --set anaconda_upload no
 
       - name: Conda Rerender
         run: |
           source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
-          mamba config --set anaconda_upload no
 
           git clone -b main https://github.com/conda-forge/cmor-feedstock $PROJECT_DIR/cmor-feedstock
           export SRC_META_YAML=`pwd`/$PROJECT_DIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -103,7 +101,6 @@ jobs:
           source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
-          mamba config --set anaconda_upload no
           mamba activate smithy_env
 
           export BUILD_DIR=`pwd`/cmor_conda_pkgs
@@ -123,7 +120,6 @@ jobs:
           source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
-          mamba config --set anaconda_upload no
 
           export CMOR_CHANNEL=file://`pwd`/cmor_conda_pkgs/
           mamba search -c $CMOR_CHANNEL --override-channels
@@ -142,7 +138,6 @@ jobs:
           source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
-          mamba config --set anaconda_upload no
           mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts
           anaconda -t $CONDA_UPLOAD_TOKEN upload -u $CONDA_USER -l $CONDA_LABEL $ARTIFACT_DIR/*/*.tar.bz2 --force

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -59,12 +59,14 @@ jobs:
         run: |
           curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
           bash miniforge3.sh -b -p $PROJECT_DIR/miniforge3
+          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba config --set anaconda_upload no
 
       - name: Conda Rerender
         run: |
+          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba config --set anaconda_upload no
@@ -98,6 +100,7 @@ jobs:
 
       - name: Conda Build
         run: |
+          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba config --set anaconda_upload no
@@ -117,6 +120,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba config --set anaconda_upload no
@@ -135,6 +139,7 @@ jobs:
           CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
+          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba config --set anaconda_upload no


### PR DESCRIPTION
Replaces miniconda in our development pipeline with miniforge.  A workaround until we can come up with a pip-installed alternative for CMOR.

Motivated by discussion in #768.