### PR TITLE
Make quantization meet CF compliance

### DIFF
--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -5299,15 +5299,15 @@ void cmor_create_var_attributes(int var_id, int ncid, int ncafid,
                 QUANTIZATION_IMPLEMENTATION, strlen(pVar->quantize_info.implementation),
                 pVar->quantize_info.implementation);
             ierr |= nc_put_att_text(ncid, pVar->nc_var_id,
-                QUANTIZATION_ATTR, strlen(QUANTIZATION_INFO),
+                VARIALBE_ATT_QUANTIZATION, strlen(QUANTIZATION_INFO),
                 QUANTIZATION_INFO);
             if (icqm == NC_QUANTIZE_BITGROOM
                 || icqm == NC_QUANTIZE_GRANULARBR) {
                 ierr |= nc_put_att_int(ncid, pVar->nc_var_id,
-                    QUANTIZATION_NSD, NC_INT, 1, &icqn);
+                    VARIALBE_ATT_QUANTIZATION_NSD, NC_INT, 1, &icqn);
             } else if (icqm == NC_QUANTIZE_BITROUND) {
                 ierr |= nc_put_att_int(ncid, pVar->nc_var_id,
-                    QUANTIZATION_NSB, NC_INT, 1, &icqn);
+                    VARIALBE_ATT_QUANTIZATION_NSB, NC_INT, 1, &icqn);
             }
         }
 

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -5301,6 +5301,14 @@ void cmor_create_var_attributes(int var_id, int ncid, int ncafid,
             ierr |= nc_put_att_text(ncid, pVar->nc_var_id,
                 QUANTIZATION_ATTR, strlen(QUANTIZATION_INFO),
                 QUANTIZATION_INFO);
+            if (icqm == NC_QUANTIZE_BITGROOM
+                || icqm == NC_QUANTIZE_GRANULARBR) {
+                ierr |= nc_put_att_int(ncid, pVar->nc_var_id,
+                    QUANTIZATION_NSD, NC_INT, 1, &icqn);
+            } else if (icqm == NC_QUANTIZE_BITROUND) {
+                ierr |= nc_put_att_int(ncid, pVar->nc_var_id,
+                    QUANTIZATION_NSB, NC_INT, 1, &icqn);
+            }
         }
 
         // Only use zstandard compression if deflate is disabled

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -1940,7 +1940,7 @@ int cmor_define_zfactors_vars(int var_id, int ncid, int *nc_dim,
     int ierr = 0, l, m, k, n, j, m2, found, nelts, *int_list = NULL;
     int dim_holder[CMOR_MAX_VARIABLES];
     int lnzfactors;
-    int ics, icd, icdl, icz, icqm, icqn, ia;
+    int ics, icd, icdl, icz, ia;
     cmor_add_traceback("cmor_define_zfactors_vars");
     cmor_is_setup();
     lnzfactors = *nzfactors;
@@ -2142,13 +2142,7 @@ int cmor_define_zfactors_vars(int var_id, int ncid, int *nc_dim,
                           cmor_tables[nTableID].vars[nTableID].deflate_level;
                         icz =
                           cmor_tables[nTableID].vars[nTableID].zstandard_level;
-                        icqm =
-                          cmor_tables[nTableID].vars[nTableID].quantize_mode;
-                        icqn =
-                          cmor_tables[nTableID].vars[nTableID].quantize_nsd;
 
-                        ierr = nc_def_var_quantize(ncid, nc_zfactors[lnzfactors],
-                                                icqm, icqn);
                         if (icd != 0) {
                             ierr |= nc_def_var_deflate(ncid, nc_zfactors[lnzfactors],
                                                     ics, icd, icdl);
@@ -3528,7 +3522,7 @@ void cmor_define_dimensions(int var_id, int ncid,
     int tmp_dims[2];
     int dims_bnds_ids[2];
     int nVarRefTblID = cmor_vars[var_id].ref_table_id;
-    int ics, icd, icdl, icz, icqm, icqn;
+    int ics, icd, icdl, icz;
     int itmpmsg, itmp2, itmp3;
     int maxStrLen;
 
@@ -3884,11 +3878,7 @@ void cmor_define_dimensions(int var_id, int ncid,
                 icd = pVar->deflate;
                 icdl = pVar->deflate_level;
                 icz = pVar->zstandard_level;
-                icqm = pVar->quantize_mode;
-                icqn = pVar->quantize_nsd;
 
-                ierr = nc_def_var_quantize(ncafid, nc_bnds_vars[i], icqm,
-                                        icqn);
                 if (icd != 0) {
                     ierr |= nc_def_var_deflate(ncafid, nc_bnds_vars[i],
                                             ics, icd, icdl);
@@ -4153,7 +4143,7 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
     int *int_list = NULL;
     char mtype;
     int nelts;
-    int ics, icd, icdl, icz, icqm, icqn;
+    int ics, icd, icdl, icz;
 
     cmor_add_traceback("cmor_grids_def");
 /* -------------------------------------------------------------------- */
@@ -4428,16 +4418,7 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
                       cmor_tables[cmor_vars[j].ref_table_id].vars[cmor_vars[j].
                                                                   ref_var_id].
                       zstandard_level;
-                    icqm =
-                      cmor_tables[cmor_vars[j].ref_table_id].vars[cmor_vars[j].
-                                                                  ref_var_id].
-                      quantize_mode;
-                    icqn =
-                      cmor_tables[cmor_vars[j].ref_table_id].vars[cmor_vars[j].
-                                                                  ref_var_id].
-                      quantize_nsd;
-                    ierr = nc_def_var_quantize(ncafid, nc_associated_vars[i],
-                                            icqm, icqn);
+
                     if (icd != 0) {
                         ierr |= nc_def_var_deflate(ncafid, nc_associated_vars[i],
                                                 ics, icd, icdl);

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -5395,6 +5395,18 @@ void cmor_create_var_attributes(int var_id, int ncid, int ncafid,
             ierr |= nc_put_att_text(ncid, quantize_info_ncid,
                 QUANTIZATION_IMPLEMENTATION, strlen(msg), msg);
             ierr |= nc_def_var_quantize(ncid, pVar->nc_var_id, icqm, icqn);
+
+            if (ierr != NC_NOERR) {
+                cmor_handle_error_var_variadic(
+                    "NetCDF Error (%i: %s) defining quantization\n! "
+                    "parameters for variable '%s' (table: %s)",
+                    CMOR_CRITICAL, var_id,
+                    ierr, nc_strerror(ierr), pVar->id,
+                    cmor_tables[nVarRefTblID].szTable_id);
+                cmor_pop_traceback();
+                return;
+    
+            }
         }
 
         // Only use zstandard compression if deflate is disabled

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <regex.h>
 #include "cmor.h"
+#include <netcdf.h>
 #include <json-c/json.h>
 #include <json-c/json_tokener.h>
 #include <json-c/arraylist.h>
@@ -2448,12 +2449,13 @@ int cmor_CV_variable(int *var_id, char *name, char *units,
     cmor_vars[vrid].deflate = refvar.deflate;
     cmor_vars[vrid].deflate_level = refvar.deflate_level;
     cmor_vars[vrid].zstandard_level = refvar.zstandard_level;
-    cmor_vars[vrid].quantize_mode = refvar.quantize_mode;
-    cmor_vars[vrid].quantize_nsd = refvar.quantize_nsd;
     cmor_vars[vrid].first_bound = startimebnds;
     cmor_vars[vrid].last_bound = endtimebnds;
     cmor_vars[vrid].first_time = startime;
     cmor_vars[vrid].last_time = endtime;
+
+    cmor_vars[vrid].quantize_mode = NC_NOQUANTIZE;
+    cmor_vars[vrid].quantize_nsd = 1;
 
     if (refvar.out_name[0] == '\0') {
         strncpy(cmor_vars[vrid].id, name, CMOR_MAX_STRING);

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2323,13 +2323,13 @@ int cmor_set_quantize(int var_id, int quantize_mode, int quantize_nsd)
     }
 
     if (quantize_mode == NC_NOQUANTIZE) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, "no_quantization");
+        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_NOQUANTIZATION);
     } else if (quantize_mode == NC_QUANTIZE_BITGROOM) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, "bitgroom");
+        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_BITGROOM);
     } else if (quantize_mode == NC_QUANTIZE_BITROUND) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, "bitround");
+        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_BITROUND);
     } else if (quantize_mode == NC_QUANTIZE_GRANULARBR) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, "granular_bitround");
+        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_GRANULARBITROUND);
     } else {
         cmor_handle_error_variadic(
             "Unsupported quantization mode %d",

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2322,26 +2322,6 @@ int cmor_set_quantize(int var_id, int quantize_mode, int quantize_nsd)
         return (-1);
     }
 
-    if (quantize_mode == NC_NOQUANTIZE) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_NOQUANTIZATION);
-    } else if (quantize_mode == NC_QUANTIZE_BITGROOM) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_BITGROOM);
-    } else if (quantize_mode == NC_QUANTIZE_BITROUND) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_BITROUND);
-    } else if (quantize_mode == NC_QUANTIZE_GRANULARBR) {
-        strcpy(cmor_vars[var_id].quantize_info.algorithm, QUANTIZATION_GRANULARBITROUND);
-    } else {
-        cmor_handle_error_variadic(
-            "Unsupported quantization mode %d",
-            CMOR_CRITICAL, quantize_mode);
-        cmor_pop_traceback();
-
-        return (-1);
-    }
-
-    sprintf(cmor_vars[var_id].quantize_info.implementation,
-            "libnetcdf version %s", nc_inq_libvers());
-
     cmor_vars[var_id].quantize_mode = quantize_mode;
     cmor_vars[var_id].quantize_nsd = quantize_nsd;
     cmor_pop_traceback();

--- a/Test/test_cmor_zstandard_and_quantize.py
+++ b/Test/test_cmor_zstandard_and_quantize.py
@@ -167,18 +167,73 @@ class TestCase(unittest.TestCase):
             self.assertTrue('quantization_nsd' in quantized_attributes)
             self.assertTrue('quantization_nsb' not in quantized_attributes)
 
-            quantize_attr = quantized_ta.getncattr('quantization')
-            quantize_nsd = quantized_ta.getncattr('quantization_nsd')
+            quantized_attr = quantized_ta.getncattr('quantization')
+            quantized_nsd = quantized_ta.getncattr('quantization_nsd')
 
-            self.assertEqual(quantize_attr, 'quantization_info')
-            self.assertEqual(quantize_nsd, 4)
+            self.assertEqual(quantized_attr, 'quantization_info')
+            self.assertEqual(quantized_nsd, 4)
 
-            quantize_info = quantized_nc.variables['quantization_info']
-            quantize_alg = quantize_info.getncattr('algorithm')
-            quantize_impl = quantize_info.getncattr('implementation')
+            quantized_info = quantized_nc.variables['quantization_info']
+            quantized_alg = quantized_info.getncattr('algorithm')
+            quantized_impl = quantized_info.getncattr('implementation')
 
-            self.assertEqual(quantize_alg, 'bitgroom')
-            self.assertTrue('libnetcdf version ' in quantize_impl)
+            self.assertEqual(quantized_alg, 'bitgroom')
+            self.assertTrue('libnetcdf version ' in quantized_impl)
+
+    def testQuantizationModes(self):
+
+        seed = 123
+        ntimes = 100
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            granular = self.gen_file(seed, ntimes, 0, True, 1, False, 2, 3, tmp_dir)
+            bitround = self.gen_file(seed, ntimes,  0, True, 1, False, 3, 6, tmp_dir)
+
+            granular_nc = Dataset(granular, "r", format="NETCDF4")
+            bitround_nc = Dataset(bitround, "r", format="NETCDF4")
+
+            granular_ta = granular_nc.variables['ta']
+            bitround_ta = bitround_nc.variables['ta']
+
+            granular_attributes = granular_ta.ncattrs()
+
+            self.assertTrue('quantization_info' in granular_nc.variables)
+            self.assertTrue('quantization' in granular_attributes)
+            self.assertTrue('quantization_nsd' in granular_attributes)
+            self.assertTrue('quantization_nsb' not in granular_attributes)
+
+            granular_attr = granular_ta.getncattr('quantization')
+            granular_nsd = granular_ta.getncattr('quantization_nsd')
+
+            self.assertEqual(granular_attr, 'quantization_info')
+            self.assertEqual(granular_nsd, 3)
+
+            granular_info = granular_nc.variables['quantization_info']
+            granular_alg = granular_info.getncattr('algorithm')
+            granular_impl = granular_info.getncattr('implementation')
+
+            self.assertEqual(granular_alg, 'granular_bitround')
+            self.assertTrue('libnetcdf version ' in granular_impl)
+
+            bitround_attributes = bitround_ta.ncattrs()
+
+            self.assertTrue('quantization_info' in bitround_nc.variables)
+            self.assertTrue('quantization' in bitround_attributes)
+            self.assertTrue('quantization_nsd' not in bitround_attributes)
+            self.assertTrue('quantization_nsb' in bitround_attributes)
+
+            bitround_attr = bitround_ta.getncattr('quantization')
+            bitround_nsd = bitround_ta.getncattr('quantization_nsb')
+
+            self.assertEqual(bitround_attr, 'quantization_info')
+            self.assertEqual(bitround_nsd, 6)
+
+            bitround_info = bitround_nc.variables['quantization_info']
+            bitround_alg = bitround_info.getncattr('algorithm')
+            bitround_impl = bitround_info.getncattr('implementation')
+
+            self.assertEqual(bitround_alg, 'bitround')
+            self.assertTrue('libnetcdf version ' in bitround_impl)
 
 
 if __name__ == '__main__':

--- a/Test/test_cmor_zstandard_and_quantize.py
+++ b/Test/test_cmor_zstandard_and_quantize.py
@@ -145,9 +145,40 @@ class TestCase(unittest.TestCase):
             default_nc = Dataset(default, "r", format="NETCDF4")
             quantized_nc = Dataset(quantized, "r", format="NETCDF4")
 
-            default_ta = default_nc.variables['ta'][:]
-            quantized_ta = quantized_nc.variables['ta'][:]
-            self.assertIsNone(numpy.testing.assert_allclose(default_ta, quantized_ta, rtol=1e-4))
+            default_ta = default_nc.variables['ta']
+            quantized_ta = quantized_nc.variables['ta']
+            self.assertIsNone(
+                numpy.testing.assert_allclose(default_ta[:],
+                                              quantized_ta[:],
+                                              rtol=1e-4)
+            )
+
+            default_attributes = default_ta.ncattrs()
+
+            self.assertTrue('quantization_info' not in default_nc.variables)
+            self.assertTrue('quantization' not in default_attributes)
+            self.assertTrue('quantization_nsd' not in default_attributes)
+            self.assertTrue('quantization_nsb' not in default_attributes)
+
+            quantized_attributes = quantized_ta.ncattrs()
+
+            self.assertTrue('quantization_info' in quantized_nc.variables)
+            self.assertTrue('quantization' in quantized_attributes)
+            self.assertTrue('quantization_nsd' in quantized_attributes)
+            self.assertTrue('quantization_nsb' not in quantized_attributes)
+
+            quantize_attr = quantized_ta.getncattr('quantization')
+            quantize_nsd = quantized_ta.getncattr('quantization_nsd')
+
+            self.assertEqual(quantize_attr, 'quantization_info')
+            self.assertEqual(quantize_nsd, 4)
+
+            quantize_info = quantized_nc.variables['quantization_info']
+            quantize_alg = quantize_info.getncattr('algorithm')
+            quantize_impl = quantize_info.getncattr('implementation')
+
+            self.assertEqual(quantize_alg, 'bitgroom')
+            self.assertTrue('libnetcdf version ' in quantize_impl)
 
 
 if __name__ == '__main__':

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -270,6 +270,8 @@
 #define EXTERNAL_VARIABLE_REGEX       "[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+)([[:blank:]]*[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 
 #define QUANTIZATION_ATTR            "quantization"
+#define QUANTIZATION_NSB             "quantization_nsb"
+#define QUANTIZATION_NSD             "quantization_nsd"
 #define QUANTIZATION_INFO            "quantization_info"
 #define QUANTIZATION_ALGORITHM       "algorithm"
 #define QUANTIZATION_IMPLEMENTATION  "implementation"

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -135,8 +135,6 @@
 #define VARIABLE_ATT_DEFLATE          "deflate"
 #define VARIABLE_ATT_DEFLATELEVEL     "deflate_level"
 #define VARIABLE_ATT_ZSTANDARDLEVEL   "zstandard_level"
-#define VARIABLE_ATT_QUANTIZEMODE     "quantize_mode"
-#define VARIABLE_ATT_QUANTIZENSD      "quantize_nsd"
 #define VARIABLE_ATT_MODELINGREALM    "modeling_realm"
 #define VARIALBE_ATT_FREQUENCY        "frequency"
 #define VARIABLE_ATT_FLAGVALUES       "flag_values"
@@ -271,6 +269,11 @@
 //#define EXTERNAL_VARIABLE_REGEX       "([[:alpha:]]+):[[:blank:]]*([[:alpha:]]+)[[:blank:]]*([[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 #define EXTERNAL_VARIABLE_REGEX       "[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+)([[:blank:]]*[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 
+#define QUANTIZATION_ATTR            "quantization"
+#define QUANTIZATION_INFO            "quantization_info"
+#define QUANTIZATION_ALGORITHM       "algorithm"
+#define QUANTIZATION_IMPLEMENTATION  "implementation"
+
 extern int CMOR_TERMINATE_SIGNAL;
 extern int USE_NETCDF_4;
 extern int CMOR_MODE;
@@ -401,6 +404,12 @@ typedef struct cmor_axis_ {
 } cmor_axis_t;
 extern cmor_axis_t cmor_axes[CMOR_MAX_AXES];
 
+typedef struct cmor_quantization_info_ {
+    int nc_var_id;
+    char algorithm[CMOR_MAX_STRING];
+    char implementation[CMOR_MAX_STRING];
+} cmor_quantization_info_t;
+
 typedef struct cmor_variable_def_ {
     int table_id;
     char id[CMOR_MAX_STRING];
@@ -426,8 +435,6 @@ typedef struct cmor_variable_def_ {
     int deflate;
     int deflate_level;
     int zstandard_level;
-    int quantize_mode;
-    int quantize_nsd;
     char required[CMOR_MAX_STRING];
     char realm[CMOR_MAX_STRING];
     char frequency[CMOR_MAX_STRING];
@@ -482,6 +489,7 @@ typedef struct cmor_var_ {
     int zstandard_level;
     int quantize_mode;
     int quantize_nsd;
+    cmor_quantization_info_t quantize_info;
     int nomissing;
     char iunits[CMOR_MAX_STRING];
     char ounits[CMOR_MAX_STRING];

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -125,6 +125,9 @@
 #define VARIABLE_ATT_EXTCELLMEASURES  "ext_cell_measures"
 #define VARIABLE_ATT_CELLMEASURES     "cell_measures"
 #define VARIALBE_ATT_GRIDMAPPING      "grid_mapping"
+#define VARIALBE_ATT_QUANTIZATION     "quantization"
+#define VARIALBE_ATT_QUANTIZATION_NSB "quantization_nsb"
+#define VARIALBE_ATT_QUANTIZATION_NSD "quantization_nsd"
 
 #define VARIABLE_ATT_VALIDMIN         "valid_min"
 #define VARIABLE_ATT_VALIDMAX         "valid_max"
@@ -269,12 +272,13 @@
 //#define EXTERNAL_VARIABLE_REGEX       "([[:alpha:]]+):[[:blank:]]*([[:alpha:]]+)[[:blank:]]*([[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 #define EXTERNAL_VARIABLE_REGEX       "[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+)([[:blank:]]*[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 
-#define QUANTIZATION_ATTR            "quantization"
-#define QUANTIZATION_NSB             "quantization_nsb"
-#define QUANTIZATION_NSD             "quantization_nsd"
-#define QUANTIZATION_INFO            "quantization_info"
-#define QUANTIZATION_ALGORITHM       "algorithm"
-#define QUANTIZATION_IMPLEMENTATION  "implementation"
+#define QUANTIZATION_INFO              "quantization_info"
+#define QUANTIZATION_ALGORITHM         "algorithm"
+#define QUANTIZATION_IMPLEMENTATION    "implementation"
+#define QUANTIZATION_NOQUANTIZATION    "no_quantization"
+#define QUANTIZATION_BITGROOM          "bitgroom"
+#define QUANTIZATION_BITROUND          "bitround"
+#define QUANTIZATION_GRANULARBITROUND  "granular_bitround"
 
 extern int CMOR_TERMINATE_SIGNAL;
 extern int USE_NETCDF_4;

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -410,12 +410,6 @@ typedef struct cmor_axis_ {
 } cmor_axis_t;
 extern cmor_axis_t cmor_axes[CMOR_MAX_AXES];
 
-typedef struct cmor_quantization_info_ {
-    int nc_var_id;
-    char algorithm[CMOR_MAX_STRING];
-    char implementation[CMOR_MAX_STRING];
-} cmor_quantization_info_t;
-
 typedef struct cmor_variable_def_ {
     int table_id;
     char id[CMOR_MAX_STRING];
@@ -495,7 +489,6 @@ typedef struct cmor_var_ {
     int zstandard_level;
     int quantize_mode;
     int quantize_nsd;
-    cmor_quantization_info_t quantize_info;
     int nomissing;
     char iunits[CMOR_MAX_STRING];
     char ounits[CMOR_MAX_STRING];


### PR DESCRIPTION
Resolves #765

CMOR will now only apply quantization to the dataset variable and not the axes, zfactors, or grids. When quantization is applied, the variable `quantization_info` will be created in the netCDF file that will contain the quantization algorithm used (`bitgroom`, `bitround`, and `granular_bitround`) and the libnetcdf library version. The dataset variable will now have the attribute `quantization_nsb` or `quantization_nsd` depending on the algorithm used.

@durack1 @taylor13 @czender