### PR TITLE
Handle variables that have a branding suffix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -231,6 +231,7 @@ test_python: python
 	env TEST_NAME=Test/test_python_forecast_coordinates.py make test_a_python
 	env TEST_NAME=Test/test_cmor_CMIP6Plus.py make test_a_python
 	env TEST_NAME=Test/test_cmor_zstandard_and_quantize.py make test_a_python
+	env TEST_NAME=Test/test_python_branded_variable.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -3067,6 +3067,34 @@ int cmor_setGblAttr(int var_id)
                                             "", 0);
 
 /* -------------------------------------------------------------------- */
+/*     Set branded variable attributes                                  */
+/* -------------------------------------------------------------------- */
+    if (cmor_vars[var_id].branding_suffix[0] != '\0') {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_BRANDINGSUFFIX,
+                                                cmor_vars[var_id].branding_suffix,
+                                                0);
+    }
+    if (cmor_vars[var_id].temporal_label[0] != '\0') {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_TEMPORALLABEL,
+                                                cmor_vars[var_id].temporal_label,
+                                                0);
+    }
+    if (cmor_vars[var_id].vertical_label[0] != '\0') {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_VERTICALLABEL,
+                                                cmor_vars[var_id].vertical_label,
+                                                0);
+    }
+    if (cmor_vars[var_id].horizontal_label[0] != '\0') {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_HORIZONTALLABEL,
+                                                cmor_vars[var_id].horizontal_label,
+                                                0);
+    }
+    if (cmor_vars[var_id].area_label[0] != '\0') {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_AREALABEL,
+                                                cmor_vars[var_id].area_label,
+                                                0);
+    }
+/* -------------------------------------------------------------------- */
 /*     Create external_variables                                        */
 /* -------------------------------------------------------------------- */
     if (cmor_has_variable_attribute(var_id, VARIABLE_ATT_CELLMEASURES) == 0) {

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2113,10 +2113,12 @@ int cmor_CV_checkGrids(cmor_CV_def_t * CV)
                                        szGridResolution);
     }
 
+    cmor_get_cur_dataset_attribute(CV_INPUTFILENAME, CV_Filename);
+
     CV_grid_labels = cmor_CV_rootsearch(CV, CV_KEY_GRID_LABELS);
     if (CV_grid_labels == NULL) {
         cmor_handle_error_variadic(
-                 "Your \"grid_labels\" key could not be found in\n! "
+                 "Your \"grid_label\" key could not be found in\n! "
                  "your Control Vocabulary file.(%s)\n! ", CMOR_NORMAL, CV_Filename);
 
         cmor_pop_traceback();
@@ -2159,9 +2161,8 @@ int cmor_CV_checkGrids(cmor_CV_def_t * CV)
     CV_grid_resolution = cmor_CV_rootsearch(CV, CV_KEY_GRID_RESOLUTION);
     if (CV_grid_resolution == NULL) {
         cmor_handle_error_variadic(
-                 "Your attribute grid_label is set to \"%s\" which is invalid."
-                 "\n! \n! Check your Control Vocabulary file \"%s\".\n! ",
-                 CMOR_NORMAL, szGridLabel, CV_Filename);
+                 "Your \"nominal_resolution\" key could not be found in\n! "
+                 "your Control Vocabulary file.(%s)\n! ", CMOR_NORMAL, CV_Filename);
         cmor_pop_traceback();
         return (-1);
 

--- a/Src/cmor_tables.c
+++ b/Src/cmor_tables.c
@@ -6,6 +6,7 @@
 #include <netcdf.h>
 #include <udunits2.h>
 #include <stdlib.h>
+#include <regex.h>
 #include "cmor_locale.h"
 #include <json-c/json.h>
 #include <json-c/json_tokener.h>
@@ -170,13 +171,18 @@ int cmor_set_variable_entry(cmor_table_t * table,
     extern int cmor_ntables;
     char szValue[CMOR_MAX_STRING];
     int nVarId;
-    char *szTableId;
+    int reti;
+    char *szTableId;   
     array_list *jsonArray;
     json_object *jsonItem;
     size_t k, arrayLen;
     cmor_var_def_t *variable;
     cmor_table_t *cmor_table;
     cmor_table = &cmor_tables[cmor_ntables];
+    regex_t regex;
+    size_t nmatch = 6;                                                      
+    regmatch_t pmatch[nmatch]; 
+    char *branded_var_regex = "^([[:alnum:]]+)_([[:alnum:]]+)-([[:alnum:]]+)-([[:alnum:]]+)-([[:alnum:]]+)$";
 
     szTableId = cmor_table->szTable_id;
 
@@ -202,6 +208,39 @@ int cmor_set_variable_entry(cmor_table_t * table,
 
     cmor_init_var_def(variable, cmor_ntables);
     cmor_set_var_def_att(variable, "id", variable_entry);
+
+/* -------------------------------------------------------------------- */
+/*  Check if varialbe_entry is a branded variable by splitting it into  */
+/*  its components.                                                     */
+/* -------------------------------------------------------------------- */
+    reti = regcomp(&regex, branded_var_regex, REG_EXTENDED);
+    reti |= regexec(&regex, variable_entry, nmatch, pmatch, 0);
+    if(reti == 0) {
+        strncpy(variable->out_name, 
+            &variable_entry[pmatch[1].rm_so], 
+            pmatch[1].rm_eo - pmatch[1].rm_so);
+            printf("%s\n",variable->out_name);
+        strncpy(variable->temporal_label, 
+            &variable_entry[pmatch[2].rm_so], 
+            pmatch[2].rm_eo - pmatch[2].rm_so);
+            printf("%s\n",variable->temporal_label);
+        strncpy(variable->vertical_label, 
+            &variable_entry[pmatch[3].rm_so], 
+            pmatch[3].rm_eo - pmatch[3].rm_so);
+            printf("%s\n",variable->vertical_label);
+        strncpy(variable->horizontal_label, 
+            &variable_entry[pmatch[4].rm_so], 
+            pmatch[4].rm_eo - pmatch[4].rm_so);
+            printf("%s\n",variable->horizontal_label);
+        strncpy(variable->area_label, 
+            &variable_entry[pmatch[5].rm_so], 
+            pmatch[5].rm_eo - pmatch[5].rm_so);
+            printf("%s\n",variable->area_label);
+        strncpy(variable->branding_suffix, 
+            &variable_entry[pmatch[2].rm_so], 
+            pmatch[5].rm_eo - pmatch[2].rm_so);
+            printf("%s\n",variable->branding_suffix);
+    }
 
     json_object_object_foreach(json, attr, value) {
 /* -------------------------------------------------------------------- */

--- a/Src/cmor_tables.c
+++ b/Src/cmor_tables.c
@@ -219,27 +219,21 @@ int cmor_set_variable_entry(cmor_table_t * table,
         strncpy(variable->out_name, 
             &variable_entry[pmatch[1].rm_so], 
             pmatch[1].rm_eo - pmatch[1].rm_so);
-            printf("%s\n",variable->out_name);
         strncpy(variable->temporal_label, 
             &variable_entry[pmatch[2].rm_so], 
             pmatch[2].rm_eo - pmatch[2].rm_so);
-            printf("%s\n",variable->temporal_label);
         strncpy(variable->vertical_label, 
             &variable_entry[pmatch[3].rm_so], 
             pmatch[3].rm_eo - pmatch[3].rm_so);
-            printf("%s\n",variable->vertical_label);
         strncpy(variable->horizontal_label, 
             &variable_entry[pmatch[4].rm_so], 
             pmatch[4].rm_eo - pmatch[4].rm_so);
-            printf("%s\n",variable->horizontal_label);
         strncpy(variable->area_label, 
             &variable_entry[pmatch[5].rm_so], 
             pmatch[5].rm_eo - pmatch[5].rm_so);
-            printf("%s\n",variable->area_label);
         strncpy(variable->branding_suffix, 
             &variable_entry[pmatch[2].rm_so], 
             pmatch[5].rm_eo - pmatch[2].rm_so);
-            printf("%s\n",variable->branding_suffix);
     }
 
     json_object_object_foreach(json, attr, value) {

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -1152,6 +1152,12 @@ int cmor_variable(int *var_id, char *name, char *units, int ndims,
         strncpy(cmor_vars[vrid].id, refvar.out_name, CMOR_MAX_STRING);
     }
 
+    strncpy(cmor_vars[vrid].branding_suffix, refvar.branding_suffix, CMOR_MAX_STRING);
+    strncpy(cmor_vars[vrid].temporal_label, refvar.temporal_label, CMOR_MAX_STRING);
+    strncpy(cmor_vars[vrid].vertical_label, refvar.vertical_label, CMOR_MAX_STRING);
+    strncpy(cmor_vars[vrid].horizontal_label, refvar.horizontal_label, CMOR_MAX_STRING);
+    strncpy(cmor_vars[vrid].area_label, refvar.area_label, CMOR_MAX_STRING);
+
     cmor_set_variable_attribute_internal(vrid, VARIABLE_ATT_STANDARDNAME, 'c',
                                          refvar.standard_name);
 
@@ -1903,6 +1909,11 @@ void cmor_init_var_def(cmor_var_def_t * var, int table_id)
     var->quantize_mode = 0;
     var->quantize_nsd = 1;
     var->generic_level_name[0] = '\0';
+    var->branding_suffix[0] = '\0';
+    var->temporal_label[0] = '\0';
+    var->vertical_label[0] = '\0';
+    var->horizontal_label[0] = '\0';
+    var->area_label[0] = '\0';
 }
 
 /************************************************************************/
@@ -2163,6 +2174,26 @@ int cmor_set_var_def_att(cmor_var_def_t * var, char *att, char *val)
     } else if (strcmp(att, VARIABLE_ATT_OUTNAME) == 0) {
 
         strncpy(var->out_name, val, CMOR_MAX_STRING);
+
+    } else if (strcmp(att, VARIABLE_ATT_BRANDINGSUFFIX) == 0) {
+
+        strncpy(var->branding_suffix, val, CMOR_MAX_STRING);
+
+    } else if (strcmp(att, VARIABLE_ATT_TEMPORALLABEL) == 0) {
+
+        strncpy(var->temporal_label, val, CMOR_MAX_STRING);
+
+    } else if (strcmp(att, VARIABLE_ATT_VERTICALLABEL) == 0) {
+
+        strncpy(var->vertical_label, val, CMOR_MAX_STRING);
+
+    } else if (strcmp(att, VARIABLE_ATT_HORIZONTALLABEL) == 0) {
+
+        strncpy(var->horizontal_label, val, CMOR_MAX_STRING);
+
+    } else if (strcmp(att, VARIABLE_ATT_AREALABEL) == 0) {
+
+        strncpy(var->area_label, val, CMOR_MAX_STRING);
 
     } else {
         cmor_handle_error_variadic(

--- a/Test/test_python_branded_variable.py
+++ b/Test/test_python_branded_variable.py
@@ -1,0 +1,121 @@
+import json
+import cmor
+import unittest
+import os
+
+from netCDF4 import Dataset
+
+DATASET_INFO = {
+    "_AXIS_ENTRY_FILE": "Tables/CMIP6_coordinate.json",
+    "_FORMULA_VAR_FILE": "Tables/CMIP6_formula_terms.json",
+    "_control_vocabulary_file": "Tables/CMIP6_CV.json",
+    "activity_id": "CMIP",
+    "branch_method": "standard",
+    "branch_time_in_child": 30.0,
+    "branch_time_in_parent": 10800.0,
+    "calendar": "360_day",
+    "cv_version": "6.2.19.0",
+    "experiment": "AMIP",
+    "experiment_id": "amip",
+    "forcing_index": "3",
+    "further_info_url": "https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-LL.amip.none.r1i1p1f3",
+    "grid": "N96",
+    "grid_label": "gn",
+    "initialization_index": "1",
+    "institution": "Met Office Hadley Centre, Fitzroy Road, Exeter, Devon, EX1 3PB, UK",
+    "institution_id": "MOHC",
+    "license": "CMIP6 model data produced by the Met Office Hadley Centre is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https://ukesm.ac.uk/cmip6. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
+    "mip_era": "CMIP6",
+    "nominal_resolution": "250 km",
+    "outpath": ".",
+    "parent_activity_id": "no parent",
+    "physics_index": "1",
+    "realization_index": "1",
+    "source": "HadGEM3-GC31-LL (2016): \naerosol: UKCA-GLOMAP-mode\natmos: MetUM-HadGEM3-GA7.1 (N96; 192 x 144 longitude/latitude; 85 levels; top level 85 km)\natmosChem: none\nland: JULES-HadGEM3-GL7.1\nlandIce: none\nocean: NEMO-HadGEM3-GO6.0 (eORCA1 tripolar primarily 1 deg with meridional refinement down to 1/3 degree in the tropics; 360 x 330 longitude/latitude; 75 levels; top grid cell 0-1 m)\nocnBgchem: none\nseaIce: CICE-HadGEM3-GSI8 (eORCA1 tripolar primarily 1 deg; 360 x 330 longitude/latitude)",
+    "source_id": "HadGEM3-GC31-LL",
+    "source_type": "AGCM",
+    "sub_experiment": "none",
+    "sub_experiment_id": "none",
+    "tracking_prefix": "hdl:21.14100",
+    "variant_label": "r1i1p1f3"
+}
+
+
+class TestBrandedVariable(unittest.TestCase):
+    def setUp(self):
+        """
+        Write out a simple file using CMOR
+        """
+        # Set up CMOR
+        cmor.setup(inpath="TestTables", netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile="cmor.log", create_subdirectories=0)
+
+        # Define dataset using DATASET_INFO
+        with open("Test/input_branded_variable.json", "w") as input_file_handle:
+            json.dump(DATASET_INFO, input_file_handle, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json("Test/input_branded_variable.json")
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+
+    def test_variable_without_branding_suffix(self):
+        mip_table = "CMIP6_Omon_branded_variable.json"
+        table_id = cmor.load_table(mip_table)
+
+        itim = cmor.axis(
+            table_entry='time',
+            units='months since 2010-1-1',
+            coord_vals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            cell_bounds=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        ivar = cmor.variable('thetaoga', units='deg_C', axis_ids=[itim, ])
+
+        data = [280., ] * 12
+        cmor.write(ivar, data)
+        filename = cmor.close(ivar, file_name=True)
+
+        ds = Dataset(filename)
+        attrs = ds.ncattrs()
+        self.assertTrue('branding_suffix' not in attrs)
+        self.assertTrue('temporal_label' not in attrs)
+        self.assertTrue('vertical_label' not in attrs)
+        self.assertTrue('horizontal_label' not in attrs)
+        self.assertTrue('area_label' not in attrs)
+        ds.close()
+        os.remove(filename)
+
+
+    def test_variable_with_branding_suffix(self):
+        mip_table = "CMIP6_Omon_branded_variable.json"
+        table_id = cmor.load_table(mip_table)
+
+        itim = cmor.axis(
+            table_entry='time',
+            units='months since 2010-1-1',
+            coord_vals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            cell_bounds=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        ivar = cmor.variable('thetaoga_w1-x2-y3-z4', units='deg_C', axis_ids=[itim, ])
+
+        data = [280., ] * 12
+        cmor.write(ivar, data)
+        filename = cmor.close(ivar, file_name=True)
+
+        ds = Dataset(filename)
+        attrs = ds.ncattrs()
+        self.assertTrue('branding_suffix' in attrs)
+        self.assertEqual('w1-x2-y3-z4', ds.getncattr('branding_suffix'))
+        self.assertTrue('temporal_label' in attrs)
+        self.assertEqual('w1', ds.getncattr('temporal_label'))
+        self.assertTrue('vertical_label' in attrs)
+        self.assertEqual('x2', ds.getncattr('vertical_label'))
+        self.assertTrue('horizontal_label' in attrs)
+        self.assertEqual('y3', ds.getncattr('horizontal_label'))
+        self.assertTrue('area_label' in attrs)
+        self.assertEqual('z4', ds.getncattr('area_label'))
+        ds.close()
+        os.remove(filename)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/TestTables/CMIP6_Omon_branded_variable.json
+++ b/TestTables/CMIP6_Omon_branded_variable.json
@@ -1,0 +1,54 @@
+{
+    "Header": {
+        "data_specs_version": "01.00.33", 
+        "cmor_version": "3.5", 
+        "table_id": "Table Omon", 
+        "realm": "ocnBgchem", 
+        "table_date": "18 November 2020", 
+        "missing_value": "1e20", 
+        "int_missing_value": "-999", 
+        "product": "model-output", 
+        "approx_interval": "30.00000", 
+        "generic_levels": "olevel olevhalf", 
+        "mip_era": "CMIP6", 
+        "Conventions": "CF-1.7 CMIP-6.2"
+    }, 
+    "variable_entry": { 
+        "thetaoga": {
+            "frequency": "mon", 
+            "modeling_realm": "ocean", 
+            "standard_name": "sea_water_potential_temperature", 
+            "units": "degC", 
+            "cell_methods": "area: mean where sea time: mean", 
+            "cell_measures": "", 
+            "long_name": "Global Average Sea Water Potential Temperature", 
+            "comment": "Diagnostic should be contributed even for models using conservative temperature as prognostic field", 
+            "dimensions": "time", 
+            "out_name": "thetaoga", 
+            "type": "real", 
+            "positive": "", 
+            "valid_min": "", 
+            "valid_max": "", 
+            "ok_min_mean_abs": "", 
+            "ok_max_mean_abs": ""
+        },
+        "thetaoga_w1-x2-y3-z4": {
+            "frequency": "mon", 
+            "modeling_realm": "ocean", 
+            "standard_name": "sea_water_potential_temperature", 
+            "units": "degC", 
+            "cell_methods": "area: mean where sea time: mean", 
+            "cell_measures": "", 
+            "long_name": "Global Average Sea Water Potential Temperature", 
+            "comment": "Diagnostic should be contributed even for models using conservative temperature as prognostic field", 
+            "dimensions": "time", 
+            "out_name": "thetaoga", 
+            "type": "real", 
+            "positive": "", 
+            "valid_min": "", 
+            "valid_max": "", 
+            "ok_min_mean_abs": "", 
+            "ok_max_mean_abs": ""
+        }
+    }
+}

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -142,6 +142,11 @@
 #define VARIABLE_ATT_FLAGVALUES       "flag_values"
 #define VARIABLE_ATT_FLAGMEANINGS     "flag_meanings"
 #define VARIABLE_ATT_OUTNAME          "out_name"
+#define VARIABLE_ATT_BRANDINGSUFFIX   "branding_suffix"
+#define VARIABLE_ATT_TEMPORALLABEL    "temporal_label"
+#define VARIABLE_ATT_VERTICALLABEL    "vertical_label"
+#define VARIABLE_ATT_HORIZONTALLABEL  "horizontal_label"
+#define VARIABLE_ATT_AREALABEL        "area_label"
 #define COMMENT_VARIABLE_ZFACTOR      "use formula table"
 #define GLOBAL_SEPARATORS             "><"
 #define GLOBAL_OPENOPTIONAL           "["
@@ -160,6 +165,11 @@
 #define GLOBAL_ATT_ACTIVITY_ID        "activity_id"
 #define GLOBAL_ATT_VAL_NODRIVER       "no-driver"
 #define GLOBAL_ATT_VARIABLE_ID        "variable_id"
+#define GLOBAL_ATT_BRANDINGSUFFIX     "branding_suffix"
+#define GLOBAL_ATT_TEMPORALLABEL      "temporal_label"
+#define GLOBAL_ATT_VERTICALLABEL      "vertical_label"
+#define GLOBAL_ATT_HORIZONTALLABEL    "horizontal_label"
+#define GLOBAL_ATT_AREALABEL          "area_label"
 #define GLOBAL_ATT_SOURCE_ID          "source_id"
 #define GLOBAL_ATT_SOURCE             "source"
 #define GLOBAL_ATT_SUB_EXPT_ID        "sub_experiment_id"
@@ -433,6 +443,11 @@ typedef struct cmor_variable_def_ {
     char frequency[CMOR_MAX_STRING];
     char out_name[CMOR_MAX_STRING];
     char generic_level_name[CMOR_MAX_STRING];
+    char branding_suffix[CMOR_MAX_STRING];
+    char temporal_label[CMOR_MAX_STRING];
+    char vertical_label[CMOR_MAX_STRING];
+    char horizontal_label[CMOR_MAX_STRING];
+    char area_label[CMOR_MAX_STRING];
 } cmor_var_def_t;
 
 typedef struct cmor_var_ {
@@ -498,6 +513,11 @@ typedef struct cmor_var_ {
     char suffix[CMOR_MAX_STRING];
     int suffix_has_date;
     char frequency[CMOR_MAX_STRING];
+    char branding_suffix[CMOR_MAX_STRING];
+    char temporal_label[CMOR_MAX_STRING];
+    char vertical_label[CMOR_MAX_STRING];
+    char horizontal_label[CMOR_MAX_STRING];
+    char area_label[CMOR_MAX_STRING];
 } cmor_var_t;
 
 extern cmor_var_t cmor_vars[CMOR_MAX_VARIABLES];


### PR DESCRIPTION
These changes will allow CMOR to process variables that have a "branding suffix" in their table entry name as defined in #762.

There are also minor fixes to error messages for when`grid_label` or `nominal_resolution` are missing from the CV file.