### PR TITLE
configure: use correct CFLAGS and LDFLAGS variables

### DIFF
--- a/configure
+++ b/configure
@@ -4891,12 +4891,12 @@ fi
      UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
-    UDUNITS2FLAGS="-ludunits2"
-    UDUNITS2LDFLAGS=""
+    UDUNITS2LDFLAGS="-ludunits2"
+    UDUNITS2FLAGS=""
   fi
 else
-  UDUNITS2FLAGS="-ludunits2"
-  UDUNITS2LDFLAGS=""
+  UDUNITS2LDFLAGS="-ludunits2"
+  UDUNITS2FLAGS=""
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ut_parse in -ludunits2" >&5
 printf %s "checking for ut_parse in -ludunits2... " >&6; }
@@ -4975,8 +4975,8 @@ fi
      fi
     fi
   else
-    NCCFLAGS="-lnetcdf"
-    NCLDFLAGS=""
+    NCLDFLAGS="-lnetcdf"
+    NCCFLAGS=""
   fi
 else
   # Extract the first word of "nc-config", so it can be a program name with args.
@@ -5029,8 +5029,8 @@ fi
    NCCFLAGS=`${NCCONFIG} --cflags`
    NCLDFLAGS=`${NCCONFIG} --libs`
   else
-   NCCFLAGS="-lnetcdf"
-   NCLDFLAGS=""
+   NCLDFLAGS="-lnetcdf"
+   NCCFLAGS=""
   fi
 fi
 LIBS=""

--- a/configure.ac
+++ b/configure.ac
@@ -221,12 +221,12 @@ if [ test x${with_udunits2} != xyes ] ; then
      UDUNITS2LDFLAGS=" -L${with_udunits2}/lib -ludunits2"
    fi
   else
-    UDUNITS2FLAGS="-ludunits2"
-    UDUNITS2LDFLAGS=""
+    UDUNITS2LDFLAGS="-ludunits2"
+    UDUNITS2FLAGS=""
   fi
 else
-  UDUNITS2FLAGS="-ludunits2"
-  UDUNITS2LDFLAGS=""
+  UDUNITS2LDFLAGS="-ludunits2"
+  UDUNITS2FLAGS=""
 fi
 AC_CHECK_LIB([udunits2],[ut_parse],[],[AC_MSG_ERROR(Could not get a working udunits2)],[ ${UDUNITS2FLAGS} ${UDUNITS2LDFLAGS} -lm  ])
 LIBS=""
@@ -248,8 +248,8 @@ if [ test x${with_netcdf} != xyes ]; then
      fi
     fi
   else
-    NCCFLAGS="-lnetcdf"
-    NCLDFLAGS=""
+    NCLDFLAGS="-lnetcdf"
+    NCCFLAGS=""
   fi
 else
   AC_PATH_PROG(NCCONFIG,nc-config,"no")
@@ -257,8 +257,8 @@ else
    NCCFLAGS=`${NCCONFIG} --cflags`
    NCLDFLAGS=`${NCCONFIG} --libs`
   else
-   NCCFLAGS="-lnetcdf"
-   NCLDFLAGS=""
+   NCLDFLAGS="-lnetcdf"
+   NCCFLAGS=""
   fi
 fi
 LIBS=""


### PR DESCRIPTION
The `CFLAGS` and `LDFLAGS` variables were used opposite of their intended usage for the `udunits2` and `netcdf` external dependencies, so correct them.

 * `configure`: regenerate from...
 * `configure.ac`: use correct `CFLAGS` and `LDFLAGS` variables