### PR TITLE
Allow CI to run pull requests from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,10 @@ aliases:
        mamba activate base
        mamba activate smithy_env
 
-       export BUILD_DIR=`pwd`/cmor_conda_pkgs
+       export BUILD_DIR=$HOME/cmor_conda_pkgs
        mkdir -p $BUILD_DIR
 
-       export ARTIFACT_DIR=`pwd`/artifacts/$OS
+       export ARTIFACT_DIR=$HOME/artifacts/$OS
        mkdir -p $ARTIFACT_DIR
 
        if [[ $OS == 'osx-64' ]]; then
@@ -92,7 +92,7 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
-       export CMOR_CHANNEL=`pwd`/cmor_conda_pkgs/
+       export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
        mamba search -c file://$CMOR_CHANNEL --override-channels
        set +e
        mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
@@ -109,7 +109,7 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba install -n base -c conda-forge anaconda-client
-       export ARTIFACT_DIR=`pwd`/artifacts
+       export ARTIFACT_DIR=$HOME/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.conda --force
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
   - &setup_env
     name: setup_env
     command: |
-       echo "export WORKDIR=`pwd`/$PROJECT_DIR" >> $BASH_ENV
+       echo "export WORKDIR=$HOME/$PROJECT_DIR" >> $BASH_ENV
        source $BASH_ENV
        mkdir -p $WORKDIR
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,7 @@ aliases:
        python rebuild_meta_yaml.py \
         --package_name $PKG_NAME \
         --version $VERSION \
-        --organization PCMDI \
-        --repo_name $PKG_NAME \
+        --local_repo `pwd` \
         --branch $CIRCLE_BRANCH \
         --git_rev $GIT_REV \
         --build 0 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ aliases:
        export BUILD_DIR=$HOME/cmor_conda_pkgs
        mkdir -p $BUILD_DIR
 
-       export ARTIFACT_DIR=$HOME/artifacts/$OS
+       export ARTIFACT_DIR=`pwd`/artifacts/$OS
        mkdir -p $ARTIFACT_DIR
 
        if [[ $OS == 'osx-64' ]]; then
@@ -109,7 +109,7 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        mamba install -n base -c conda-forge anaconda-client
-       export ARTIFACT_DIR=$HOME/artifacts
+       export ARTIFACT_DIR=`pwd`/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.conda --force
 
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Setup Miniforge
         run: |
           curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
-          bash miniforge3.sh -b -p $PROJECT_DIR/miniforge3
-          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
-          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          bash miniforge3.sh -b -p $HOME/miniforge3
+          source $HOME/miniforge3/etc/profile.d/conda.sh
+          source $HOME/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
 
       - name: Conda Rerender
         run: |
-          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
-          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          source $HOME/miniforge3/etc/profile.d/conda.sh
+          source $HOME/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
 
           git clone -b main https://github.com/conda-forge/cmor-feedstock $PROJECT_DIR/cmor-feedstock
@@ -97,8 +97,8 @@ jobs:
 
       - name: Conda Build
         run: |
-          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
-          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          source $HOME/miniforge3/etc/profile.d/conda.sh
+          source $HOME/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba activate smithy_env
 
@@ -116,8 +116,8 @@ jobs:
 
       - name: Run Tests
         run: |
-          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
-          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          source $HOME/miniforge3/etc/profile.d/conda.sh
+          source $HOME/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
 
           export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
@@ -134,8 +134,8 @@ jobs:
           CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          source $PROJECT_DIR/miniforge3/etc/profile.d/conda.sh
-          source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
+          source $HOME/miniforge3/etc/profile.d/conda.sh
+          source $HOME/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
           mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -83,8 +83,7 @@ jobs:
             --package_name $PACKAGE_NAME \
             --version $PACKAGE_VERSION \
             --organization PCMDI \
-            --repo_name $PACKAGE_NAME \
-            --branch $GIT_BRANCH \
+            --local_repo `pwd` \
             --git_rev $GIT_REV \
             --build 0 \
             --src_meta_yaml $SRC_META_YAML \
@@ -103,7 +102,7 @@ jobs:
           mamba activate base
           mamba activate smithy_env
 
-          export BUILD_DIR=`pwd`/cmor_conda_pkgs
+          export BUILD_DIR=$HOME/cmor_conda_pkgs
           mkdir -p $BUILD_DIR
 
           export ARTIFACT_DIR=`pwd`/artifacts/$OS
@@ -121,7 +120,7 @@ jobs:
           source $PROJECT_DIR/miniforge3/etc/profile.d/mamba.sh
           mamba activate base
 
-          export CMOR_CHANNEL=file://`pwd`/cmor_conda_pkgs/
+          export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
           mamba search -c $CMOR_CHANNEL --override-channels
 
           mamba create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL python=$PYTHON_VERSION $PACKAGE_NAME=$PACKAGE_VERSION $C_COMPILER $FORTRAN_COMPILER


### PR DESCRIPTION
Resolves #782 

Build nightly from the repo directory of the CI process instead of cloning it with a URL.  This should allow pull requests from forks to be built and tested in the CI pipeline if permitted.