### PR TITLE
Updates to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ aliases:
        source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
        mamba activate base
        export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
-       mamba search -c file://$CMOR_CHANNEL --override-channels
+       # mamba search -c file://$CMOR_CHANNEL --override-channels
        set +e
        mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
        mamba activate test_py$PYTHON_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       mamba shell init
-       mamba activate base
+       eval "$(mamba shell hook --shell bash)"
+       mamba activate
 
        git clone -b main https://github.com/conda-forge/cmor-feedstock $WORKDIR/cmor-feedstock
        export SRC_META_YAML=$WORKDIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -64,8 +64,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       mamba shell init
-       mamba activate base
+       eval "$(mamba shell hook --shell bash)"
+       mamba activate
        mamba activate smithy_env
 
        export BUILD_DIR=$HOME/cmor_conda_pkgs
@@ -90,8 +90,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       mamba shell init
-       mamba activate base
+       eval "$(mamba shell hook --shell bash)"
+       mamba activate
        export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
        # mamba search -c file://$CMOR_CHANNEL --override-channels
        set +e
@@ -106,8 +106,8 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       mamba shell init
-       mamba activate base
+       eval "$(mamba shell hook --shell bash)"
+       mamba activate
        mamba install -n base -c conda-forge anaconda-client
        export ARTIFACT_DIR=`pwd`/artifacts
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $ARTIFACT_DIR/*/*.conda --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
+       mamba shell init
        mamba activate base
 
        git clone -b main https://github.com/conda-forge/cmor-feedstock $WORKDIR/cmor-feedstock
@@ -64,7 +64,7 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
+       mamba shell init
        mamba activate base
        mamba activate smithy_env
 
@@ -90,7 +90,7 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
+       mamba shell init
        mamba activate base
        export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
        # mamba search -c file://$CMOR_CHANNEL --override-channels
@@ -106,7 +106,7 @@ aliases:
     command: |
        source $BASH_ENV
        source $WORKDIR/miniforge3/etc/profile.d/conda.sh
-       source $WORKDIR/miniforge3/etc/profile.d/mamba.sh
+       mamba shell init
        mamba activate base
        mamba install -n base -c conda-forge anaconda-client
        export ARTIFACT_DIR=`pwd`/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ aliases:
        eval "$(mamba shell hook --shell bash)"
        mamba activate
        export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
-       # mamba search -c file://$CMOR_CHANNEL --override-channels
        set +e
        mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
        mamba activate test_py$PYTHON_VERSION

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -121,7 +121,6 @@ jobs:
           mamba activate
 
           export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
-          mamba search -c $CMOR_CHANNEL --override-channels
 
           mamba create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL python=$PYTHON_VERSION $PACKAGE_NAME=$PACKAGE_VERSION $C_COMPILER $FORTRAN_COMPILER
           mamba activate test_py$PYTHON_VERSION

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -60,13 +60,13 @@ jobs:
           curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
           bash miniforge3.sh -b -p $HOME/miniforge3
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          source $HOME/miniforge3/etc/profile.d/mamba.sh
+          mamba shell init
           mamba activate base
 
       - name: Conda Rerender
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          source $HOME/miniforge3/etc/profile.d/mamba.sh
+          mamba shell init
           mamba activate base
 
           git clone -b main https://github.com/conda-forge/cmor-feedstock $PROJECT_DIR/cmor-feedstock
@@ -98,7 +98,7 @@ jobs:
       - name: Conda Build
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          source $HOME/miniforge3/etc/profile.d/mamba.sh
+          mamba shell init
           mamba activate base
           mamba activate smithy_env
 
@@ -117,7 +117,7 @@ jobs:
       - name: Run Tests
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          source $HOME/miniforge3/etc/profile.d/mamba.sh
+          mamba shell init
           mamba activate base
 
           export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
@@ -135,7 +135,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          source $HOME/miniforge3/etc/profile.d/mamba.sh
+          mamba shell init
           mamba activate base
           mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -60,14 +60,14 @@ jobs:
           curl -L $MINIFORGE_INSTALLER_URL -o miniforge3.sh
           bash miniforge3.sh -b -p $HOME/miniforge3
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          mamba shell init
-          mamba activate base
+          eval "$(mamba shell hook --shell bash)"
+          mamba activate
 
       - name: Conda Rerender
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          mamba shell init
-          mamba activate base
+          eval "$(mamba shell hook --shell bash)"
+          mamba activate
 
           git clone -b main https://github.com/conda-forge/cmor-feedstock $PROJECT_DIR/cmor-feedstock
           export SRC_META_YAML=`pwd`/$PROJECT_DIR/cmor-feedstock/recipe/meta.yaml.SRC
@@ -98,8 +98,8 @@ jobs:
       - name: Conda Build
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          mamba shell init
-          mamba activate base
+          eval "$(mamba shell hook --shell bash)"
+          mamba activate
           mamba activate smithy_env
 
           export BUILD_DIR=$HOME/cmor_conda_pkgs
@@ -117,8 +117,8 @@ jobs:
       - name: Run Tests
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          mamba shell init
-          mamba activate base
+          eval "$(mamba shell hook --shell bash)"
+          mamba activate
 
           export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
           mamba search -c $CMOR_CHANNEL --override-channels
@@ -135,8 +135,8 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           source $HOME/miniforge3/etc/profile.d/conda.sh
-          mamba shell init
-          mamba activate base
+          eval "$(mamba shell hook --shell bash)"
+          mamba activate
           mamba install -n base -c conda-forge anaconda-client
           export ARTIFACT_DIR=`pwd`/artifacts
           anaconda -t $CONDA_UPLOAD_TOKEN upload -u $CONDA_USER -l $CONDA_LABEL $ARTIFACT_DIR/*/*.conda --force


### PR DESCRIPTION
This PR replaces the calling of the soon-to-be deprecated mamba.sh script with `eval "$(mamba shell hook --shell bash)"`.

It also removes the call to `mamba search`, which was causing an error with the message `specs is required`. Rather than trying to debug this issue I removed the command since it was just displaying package information for CMOR that was already being provided by the `mamba create` command.