### PR TITLE
Add function for creating a CRS variable in files

### DIFF
--- a/Lib/__init__.py
+++ b/Lib/__init__.py
@@ -8,8 +8,8 @@ from cmor.cmor_const import *
 
 from cmor.pywrapper import (
     CMORError, axis, variable, write, setup, load_table, set_table, zfactor,
-    close, grid, set_grid_mapping, time_varying_grid_coordinate, dataset_json,
-    set_cur_dataset_attribute, get_cur_dataset_attribute,
+    close, grid, set_grid_mapping, set_crs, time_varying_grid_coordinate,
+    dataset_json, set_cur_dataset_attribute, get_cur_dataset_attribute,
     has_cur_dataset_attribute, set_variable_attribute, get_variable_attribute,
     has_variable_attribute, get_final_filename, set_deflate, set_zstandard,
     set_quantize, set_furtherinfourl, set_climatology, get_climatology,

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -415,8 +415,6 @@ def set_crs(grid_id, mapping_name, parameter_names,
     else:
         raise Exception("parameter_names must be either dictionary or list")
 
-    print(tnms)
-    print(tvals)
     pvals = numpy.ascontiguousarray(pvals).astype('d')
     return _cmor.set_crs(grid_id, mapping_name, pnms, pvals, punit, tnms, tvals)
 

--- a/Lib/pywrapper.py
+++ b/Lib/pywrapper.py
@@ -341,7 +341,7 @@ def set_crs(grid_id, mapping_name, parameter_names,
     if not isinstance(mapping_name, six.string_types):
         raise Exception("mapping name must be a string")
 
-    if crs_wkt is not None or not isinstance(mapping_name, six.string_types):
+    if crs_wkt is not None and not isinstance(mapping_name, six.string_types):
         raise Exception("CRS WKT must be a string or None")
 
     if isinstance(parameter_names, dict):

--- a/Makefile.in
+++ b/Makefile.in
@@ -233,6 +233,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_zstandard_and_quantize.py make test_a_python
 	env TEST_NAME=Test/test_python_branded_variable.py make test_a_python
 	env TEST_NAME=Test/test_cmor_CMIP7.py make test_a_python
+	env TEST_NAME=Test/test_cmor_crs.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -914,7 +914,7 @@ static PyObject *PyCMOR_set_crs(PyObject * self, PyObject * args)
         strcpy(text_nms[i], PyString_AsString(tmp));
 #endif
         tmp = PyList_GetItem(param_text_val_obj, i);
-        tmp_size = PyUnicode_GET_LENGTH(tmp);
+        tmp_size = PyUnicode_GET_LENGTH(tmp) + 1;
         text_len[i] = tmp_size;
         total_size += tmp_size;
     }

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -874,7 +874,7 @@ static PyObject *PyCMOR_set_crs(PyObject * self, PyObject * args)
 
     /* HUGE assumtion here is that the data is contiguous! */
     if (!PyArg_ParseTuple
-        (args, "isOOOs", &gid, &name, &param_nm_obj, &param_val_obj,
+        (args, "isOOOz", &gid, &name, &param_nm_obj, &param_val_obj,
          &param_un_obj, &crs_wkt))
         return NULL;
 

--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -914,7 +914,7 @@ static PyObject *PyCMOR_set_crs(PyObject * self, PyObject * args)
         strcpy(text_nms[i], PyString_AsString(tmp));
 #endif
         tmp = PyList_GetItem(param_text_val_obj, i);
-        tmp_size = PyUnicode_GET_SIZE(tmp);
+        tmp_size = PyUnicode_GET_LENGTH(tmp);
         text_len[i] = tmp_size;
         total_size += tmp_size;
     }

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -1245,6 +1245,7 @@ int cmor_setup(char *path,
     cmor_current_dataset.initiated = 0;
 
     for (i = 0; i < CMOR_MAX_GRIDS; i++) {
+        strncpy(cmor_grids[i].name, "", CMOR_MAX_STRING);
         strncpy(cmor_grids[i].mapping, "", CMOR_MAX_STRING);
         cmor_grids[i].ndims = 0;
         cmor_grids[i].nattributes = 0;
@@ -4203,7 +4204,7 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
 /*      first of all checks for grid_mapping                            */
 /* -------------------------------------------------------------------- */
 
-    if (strcmp(cmor_grids[nGridID].mapping, "") != 0) {
+    if (strcmp(cmor_grids[nGridID].name, "") != 0) {
 /* -------------------------------------------------------------------- */
 /*      ok we need to create this dummy variable                        */
 /*      that contains all the info                                      */
@@ -4211,9 +4212,9 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
 
         cmor_set_variable_attribute_internal(var_id,
                                              VARIALBE_ATT_GRIDMAPPING,
-                                             'c', cmor_grids[nGridID].mapping);
+                                             'c', cmor_grids[nGridID].name);
 
-        ierr = nc_def_var(ncafid, cmor_grids[nGridID].mapping, NC_INT, 0,
+        ierr = nc_def_var(ncafid, cmor_grids[nGridID].name, NC_INT, 0,
                           &nc_dims_associated[0], &m);
 
         if (ierr != NC_NOERR) {
@@ -4223,7 +4224,7 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
                 "variable %s (table: %s)",
                 CMOR_CRITICAL, var_id,
                 ierr, nc_strerror(ierr),
-                cmor_grids[nGridID].mapping, cmor_vars[var_id].id,
+                cmor_grids[nGridID].name, cmor_vars[var_id].id,
                 cmor_tables[nVarRefTblID].szTable_id);
         }
 /* -------------------------------------------------------------------- */
@@ -4275,7 +4276,7 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
                                                  'd',
                                                  cmor_grids
                                                  [nGridID].attributes_values[k],
-                                                 cmor_grids[nGridID].mapping);
+                                                 cmor_grids[nGridID].name);
             }
         }
     }

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -1255,9 +1255,9 @@ int cmor_setup(char *path,
             cmor_grids[i].attributes_values[j] = 1.e20;
             cmor_grids[i].attributes_names[j][0] = '\0';
             cmor_grids[i].text_attributes_names[j][0] = '\0';
-            if (cmor_grids[i].text_attributes_names[j] != NULL) {
-                free(cmor_grids[i].text_attributes_names[j]);
-                cmor_grids[i].text_attributes_names[j] = NULL;
+            if (cmor_grids[i].text_attributes_values[j] != NULL) {
+                free(cmor_grids[i].text_attributes_values[j]);
+                cmor_grids[i].text_attributes_values[j] = NULL;
             }
         }
 
@@ -6967,9 +6967,9 @@ int cmor_close(void)
     }
 
     for (j = 0; j < CMOR_MAX_GRID_ATTRIBUTES; j++) {
-        if (cmor_grids[i].text_attributes_names[j] != NULL) {
-            free(cmor_grids[i].text_attributes_names[j]);
-            cmor_grids[i].text_attributes_names[j] = NULL;
+        if (cmor_grids[i].text_attributes_values[j] != NULL) {
+            free(cmor_grids[i].text_attributes_values[j]);
+            cmor_grids[i].text_attributes_values[j] = NULL;
         }
     }
 

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -1263,11 +1263,14 @@ int cmor_setup(char *path,
             free(cmor_grids[i].blats);
         if (cmor_grids[i].blons != NULL)
             free(cmor_grids[i].blons);
+        if (cmor_grids[i].crs_wkt != NULL)
+            free(cmor_grids[i].crs_wkt);
 
         cmor_grids[i].lats = NULL;
         cmor_grids[i].lons = NULL;
         cmor_grids[i].blats = NULL;
         cmor_grids[i].blons = NULL;
+        cmor_grids[i].crs_wkt = NULL;
 
         cmor_grids[i].istimevarying = 0;
         cmor_grids[i].nvertices = 0;
@@ -6969,6 +6972,10 @@ int cmor_close(void)
         if (cmor_grids[i].blats != NULL) {
             free(cmor_grids[i].blats);
             cmor_grids[i].blats = NULL;
+        }
+        if (cmor_grids[i].crs_wkt != NULL) {
+            free(cmor_grids[i].crs_wkt);
+            cmor_grids[i].crs_wkt = NULL;
         }
     }
     if ((cmor_nerrors != 0 || cmor_nwarnings != 0)) {

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -4282,6 +4282,12 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
                                                  cmor_grids[nGridID].name);
             }
         }
+        // Add crs_wkt attribute if defined
+        if(cmor_grids[nGridID].crs_wkt != NULL) {
+            ierr = cmor_put_nc_char_attribute(ncafid, m, "crs_wkt",
+                                              cmor_grids[nGridID].crs_wkt,
+                                              cmor_vars[var_id].id);
+        }
     }
 /* -------------------------------------------------------------------- */
 /*      Preps the marker for vertices dimensions                        */

--- a/Src/cmor_cfortran_interface.c
+++ b/Src/cmor_cfortran_interface.c
@@ -184,10 +184,15 @@ int cmor_set_grd_map_cff_(int *gid, char *name, int *nparam,
 int cmor_set_crs_cff_(int *gid, char *name, int *nparam,
                       char *attributes_names, int *lparam,
                       double *values, char *units, int *lnunits,
-                      char *crs_wkt)
+                      int *ntextparam, char *text_attributes_names,
+                      int *ltextparams,
+                      char *text_attributes_values,
+                      int *text_attributes_length)
 {
     return (cmor_set_crs(*gid, name, *nparam, attributes_names,
-                         *lparam, values, units, *lnunits, crs_wkt));
+                         *lparam, values, units, *lnunits, *ntextparam,
+                         text_attributes_names, *ltextparams,
+                         text_attributes_values, text_attributes_length));
 }
 
 /************************************************************************/

--- a/Src/cmor_cfortran_interface.c
+++ b/Src/cmor_cfortran_interface.c
@@ -179,6 +179,18 @@ int cmor_set_grd_map_cff_(int *gid, char *name, int *nparam,
 }
 
 /************************************************************************/
+/*                       cmor_set_crs_cff_()                            */
+/************************************************************************/
+int cmor_set_crs_cff_(int *gid, char *name, int *nparam,
+                      char *attributes_names, int *lparam,
+                      double *values, char *units, int *lnunits,
+                      char *crs_wkt)
+{
+    return (cmor_set_crs(*gid, name, *nparam, attributes_names,
+                         *lparam, values, units, *lnunits, crs_wkt));
+}
+
+/************************************************************************/
 /*                    cmor_grid_cff_noarea_double_()                    */
 /************************************************************************/
 int cmor_grid_cff_noarea_double_(int *grid_id, int *ndims, int *axes_ids,

--- a/Src/cmor_fortran_interface.f90
+++ b/Src/cmor_fortran_interface.f90
@@ -760,6 +760,17 @@ module cmor_users_functions
      end function cmor_set_grd_map_cff
   end interface
 
+  interface
+     function cmor_set_crs_cff(gid,nm,nparam,att_names,lparam,&
+          values,units,lunits,crs_wkt) result(ierr)
+       integer gid, nparam,lparam,lunits
+       character(*):: att_names,units
+       character(*) :: nm
+       double precision :: values
+       character(*) :: crs_wkt
+     end function cmor_set_crs_cff
+  end interface
+
   interface 
      function cmor_close_var_nofnm_cff(varid) result (ierr)
        integer ierr,varid
@@ -2450,6 +2461,35 @@ contains
     deallocate(paranm)
     deallocate(paraun)
   end function cmor_set_grid_mapping
+
+  function cmor_set_crs(grid_id,mapping_name,parameter_names,&
+       parameter_values,parameter_units,crs_wkt) result(ierr)
+    implicit none
+    integer :: ierr,grid_id
+    character(*) :: mapping_name
+    character(*) :: parameter_names(:),parameter_units(:)
+    double precision :: parameter_values(:)
+    character(*) :: crs_wkt
+    integer i,nparam,lparam,lunits
+    character(len=1024),allocatable ::  paranm(:),paraun(:)
+    nparam = size(parameter_values)
+    lparam = 1024
+    lunits = 1024
+    allocate(paranm(nparam))
+    allocate(paraun(nparam))
+    do i = 1,nparam
+       paranm(i) = trim(parameter_names(i))//char(0)
+       paraun(i) = trim(parameter_units(i))//char(0)
+    enddo
+    
+    ierr = cmor_set_crs_cff(grid_id,trim(mapping_name)//char(0),nparam,&
+                            paranm(1), lparam, &
+                            parameter_values(1), &
+                            paraun(1), lunits, &
+                            trim(crs_wkt)//char(0))
+    deallocate(paranm)
+    deallocate(paraun)
+  end function cmor_set_crs
 
 
   function cmor_grid_tvc_r(grid_id,table_entry,units,missing) result (ierr)

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -667,6 +667,7 @@ int cmor_set_grid_mapping(int gid, char *name, int nparam,
 /* -------------------------------------------------------------------- */
 
     strncpy(cmor_grids[grid_id].mapping, name, CMOR_MAX_STRING);
+    strncpy(cmor_grids[grid_id].name, name, CMOR_MAX_STRING);
     cmor_pop_traceback();
     return (0);
 }

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -673,6 +673,36 @@ int cmor_set_grid_mapping(int gid, char *name, int nparam,
 }
 
 /************************************************************************/
+/*                       cmor_set_crs()                                 */
+/************************************************************************/
+
+int cmor_set_crs(int gid, char *grid_mapping, int nparam,
+    char *attributes_names, int lparams,
+    double attributes_values[CMOR_MAX_GRID_ATTRIBUTES],
+    char *units, int lnunits, char *crs_wkt)
+{
+    int ierr, grid_id, str_size;
+
+    ierr = cmor_set_grid_mapping(gid, grid_mapping, nparam,
+        attributes_names, lparams, attributes_values,
+        units, lnunits);
+
+    grid_id = -gid - CMOR_MAX_GRIDS;
+    strncpy(cmor_grids[grid_id].name, "crs", CMOR_MAX_STRING);
+
+    if (cmor_grids[grid_id].crs_wkt != NULL) {
+        free(cmor_grids[grid_id].crs_wkt);
+    }
+    str_size = strlen(crs_wkt);
+    cmor_grids[grid_id].crs_wkt = malloc(str_size * sizeof(char));
+    strncpy(cmor_grids[grid_id].crs_wkt, crs_wkt, str_size);
+
+    cmor_add_traceback("cmor_set_grid_mapping");
+    cmor_pop_traceback();
+    return (ierr);
+}
+
+/************************************************************************/
 /*                 cmor_time_varying_grid_coordinate()                  */
 /************************************************************************/
 

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -24,14 +24,8 @@ void cmor_init_grid_mapping(cmor_mappings_t * mapping, char *id)
     cmor_is_setup();
 
     mapping->nattributes = 0;
-    mapping->ntextattributes = 0;
     for (n = 0; n < CMOR_MAX_GRID_ATTRIBUTES; n++) {
         mapping->attributes_names[n][0] = '\0';
-        mapping->text_attributes_names[n][0] = '\0';
-        if (mapping->text_attributes_names[n] != NULL) {
-            free(mapping->text_attributes_names[n]);
-            mapping->text_attributes_names[n] = NULL;
-        }
     }
 
     strcpy(mapping->coordinates, "");

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -326,8 +326,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "azimuthal_equidistant") == 0) {
         *natt = 4;
         strcpy(att[0], "longitude_of_projection_origin");
@@ -335,17 +335,29 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
+    } else if (strcmp(name, "geostationary") == 0) {
+        *natt = 7;
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
+        strcpy(att[2], "perspective_point_height");
+        strcpy(att[3], "sweep_angle_axis");
+        strcpy(att[4], "fixed_angle_axis");
+        strcpy(att[5], "false_easting");
+        strcpy(att[6], "false_northing");
+        *ndims = 2;
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "lambert_azimuthal_equal_area") == 0) {
         *natt = 4;
-        strcpy(att[0], "longitude_of_projection_origin");
-        strcpy(att[1], "latitude_of_projection_origin");
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "lambert_conformal_conic") == 0) {
         *natt = 5;
         strcpy(att[0], "standard_parallel");
@@ -354,52 +366,62 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "lambert_cylindrical_equal_area") == 0) {
-        *natt = 5;
+        *natt = 4;
         strcpy(att[0], "standard_parallel");
         strcpy(att[1], "longitude_of_central_meridian");
-        strcpy(att[2], "scale_factor_at_projection_origin");
-        strcpy(att[3], "false_easting");
-        strcpy(att[4], "false_northing");
+        strcpy(att[2], "false_easting");
+        strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "latitude_longitude") == 0) {
         *natt = 0;
-        *ndims = 0;
+        *ndims = 2;
+        strcpy(dims[0], "latitude");
+        strcpy(dims[1], "longitude");
     } else if (strcmp(name, "mercator") == 0) {
         *natt = 5;
-        strcpy(att[0], "standard_parallel");
-        strcpy(att[1], "longitude_of_projection_origin");
-        strcpy(att[2], "scale_factor_at_projection_origin");
-        strcpy(att[3], "false_easting");
-        strcpy(att[4], "false_northing");
-        *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
-    } else if (strcmp(name, "orthographic") == 0) {
-        *natt = 4;
         strcpy(att[0], "longitude_of_projection_origin");
-        strcpy(att[1], "latitude_of_projection_origin");
+        strcpy(att[1], "standard_parallel");
         strcpy(att[2], "scale_factor_at_projection_origin");
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
         strcpy(dims[0], "projection_x_coordinate");
         strcpy(dims[1], "projection_y_coordinate");
-    } else if (strcmp(name, "polar_stereographic") == 0) {
+    } else if (strcmp(name, "oblique_mercator") == 0) {
         *natt = 6;
-        strcpy(att[0], "straight_vertical_longitude_from_pole");
+        strcpy(att[0], "azimuth_of_central_line");
         strcpy(att[1], "latitude_of_projection_origin");
-        strcpy(att[2], "standard_parallel");
+        strcpy(att[2], "longitude_of_projection_origin");
         strcpy(att[3], "scale_factor_at_projection_origin");
         strcpy(att[4], "false_easting");
         strcpy(att[5], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
+    } else if (strcmp(name, "orthographic") == 0) {
+        *natt = 4;
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
+        strcpy(att[2], "false_easting");
+        strcpy(att[3], "false_northing");
+        *ndims = 2;
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
+    } else if (strcmp(name, "polar_stereographic") == 0) {
+        *natt = 5;
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
+        strcpy(att[2], "standard_parallel");
+        strcpy(att[3], "false_easting");
+        strcpy(att[4], "false_northing");
+        *ndims = 2;
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "rotated_latitude_longitude") == 0) {
         *natt = 3;
         strcpy(att[0], "grid_north_pole_latitude");
@@ -408,16 +430,24 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         *ndims = 2;
         strcpy(dims[0], "grid_latitude");
         strcpy(dims[1], "grid_longitude");
+    } else if (strcmp(name, "sinusoidal") == 0) {
+        *natt = 3;
+        strcpy(att[0], "longitude_of_projection_origin");
+        strcpy(att[1], "false_easting");
+        strcpy(att[2], "false_northing");
+        *ndims = 2;
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "stereographic") == 0) {
         *natt = 5;
-        strcpy(att[0], "longitude_of_projection_origin");
-        strcpy(att[1], "latitude_of_projection_origin");
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
         strcpy(att[2], "scale_factor_at_projection_origin");
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "transverse_mercator") == 0) {
         *natt = 5;
         strcpy(att[0], "scale_factor_at_central_meridian");
@@ -426,18 +456,18 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     } else if (strcmp(name, "vertical_perspective") == 0) {
         *natt = 5;
-        strcpy(att[0], "longitude_of_projection_origin");
-        strcpy(att[1], "latitude_of_projection_origin");
-        strcpy(att[2], "perspective_height_point");
+        strcpy(att[0], "latitude_of_projection_origin");
+        strcpy(att[1], "longitude_of_projection_origin");
+        strcpy(att[2], "perspective_point_height");
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_y_coordinate");
-        strcpy(dims[1], "projection_x_coordinate");
+        strcpy(dims[0], "projection_x_coordinate");
+        strcpy(dims[1], "projection_y_coordinate");
     }
 
     /* Now looks up in table */
@@ -458,10 +488,11 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[*natt + 0], "earth_radius");
         strcpy(att[*natt + 1], "inverse_flattening");
         strcpy(att[*natt + 2], "longitude_of_prime_meridian");
-        strcpy(att[*natt + 3], "perspective_point_height");
-        strcpy(att[*natt + 4], "semi_major_axis");
-        strcpy(att[*natt + 5], "semi_minor_axis");
-        *natt = *natt + 6;
+        strcpy(att[*natt + 3], "prime_meridian_name");
+        strcpy(att[*natt + 4], "reference_ellipsoid_name");
+        strcpy(att[*natt + 5], "semi_major_axis");
+        strcpy(att[*natt + 6], "semi_minor_axis");
+        *natt = *natt + 7;
     }
     return (0);
 }

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -252,8 +252,7 @@ int cmor_set_grid_attribute(int gid, char *name, double *value, char *units)
                || strcmp(name, "longitude_of_prime_meridian") == 0
                || strcmp(name, "longitude_of_central_meridian") == 0
                || strcmp(name, "longitude_of_projection_origin") == 0
-               || strcmp(name, "north_pole_grid_longitude") == 0
-               || strcmp(name, "straight_vertical_longitude_from_pole") == 0) {
+               || strcmp(name, "north_pole_grid_longitude") == 0) {
         strcpy(ctmp, "degrees_east");
         cmor_convert_value(units, ctmp, &tmp);
         if ((tmp < -180) || (tmp > 180.)) {

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -801,6 +801,7 @@ int cmor_set_crs(int gid, char *grid_mapping, int nparam,
         units, lnunits);
 
     grid_id = -gid - CMOR_MAX_GRIDS;
+    strncpy(cmor_grids[grid_id].name, "crs", CMOR_MAX_STRING);
 
     if (ntextparam >= CMOR_MAX_GRID_ATTRIBUTES) {
         cmor_handle_error_variadic(

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -683,6 +683,8 @@ int cmor_set_crs(int gid, char *grid_mapping, int nparam,
 {
     int ierr, grid_id, str_size;
 
+    cmor_add_traceback("cmor_set_grid_mapping");
+
     ierr = cmor_set_grid_mapping(gid, grid_mapping, nparam,
         attributes_names, lparams, attributes_values,
         units, lnunits);
@@ -692,12 +694,15 @@ int cmor_set_crs(int gid, char *grid_mapping, int nparam,
 
     if (cmor_grids[grid_id].crs_wkt != NULL) {
         free(cmor_grids[grid_id].crs_wkt);
+        cmor_grids[grid_id].crs_wkt = NULL;
     }
-    str_size = strlen(crs_wkt);
-    cmor_grids[grid_id].crs_wkt = malloc(str_size * sizeof(char));
-    strncpy(cmor_grids[grid_id].crs_wkt, crs_wkt, str_size);
 
-    cmor_add_traceback("cmor_set_grid_mapping");
+    if (crs_wkt != NULL) {
+        str_size = strlen(crs_wkt);
+        cmor_grids[grid_id].crs_wkt = malloc(str_size * sizeof(char));
+        strncpy(cmor_grids[grid_id].crs_wkt, crs_wkt, str_size);
+    }
+
     cmor_pop_traceback();
     return (ierr);
 }

--- a/Test/test_cmor_crs.py
+++ b/Test/test_cmor_crs.py
@@ -1,0 +1,139 @@
+import cmor
+import unittest
+import numpy
+from netCDF4 import Dataset
+from test_python_common import *
+
+
+class TestCRS(unittest.TestCase):
+
+    def make_crs_file(self, crs_wkt=None):
+        cmor.setup(inpath='cmip6-cmor-tables/Tables',
+                   netcdf_file_action=cmor.CMOR_REPLACE)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+
+        grid_table = cmor.load_table("Tables/CMIP6_grids.json")
+        lmon_table = cmor.load_table("Tables/CMIP6_Lmon.json")
+
+        cmor.set_table(grid_table)
+
+        x, y, lon_coords, lat_coords, lon_vertices, lat_vertices \
+            = gen_irreg_grid(lon, lat)
+
+        axes = [
+                {
+                    'table_entry': 'y',
+                    'units': 'm',
+                    'coord_vals': y
+                },
+                {
+                    'table_entry': 'x',
+                    'units': 'm',
+                    'coord_vals': x
+                }
+            ]
+
+        axis_ids = [cmor.axis(**axis) for axis in axes]
+
+        grid_id = cmor.grid(axis_ids=axis_ids,
+                            latitude=lat_coords,
+                            longitude=lon_coords,
+                            latitude_vertices=lat_vertices,
+                            longitude_vertices=lon_vertices)
+        axis_ids.append(grid_id)
+
+        mapnm = 'lambert_conformal_conic'
+        params = ["standard_parallel1",
+                  "longitude_of_central_meridian",
+                  "latitude_of_projection_origin",
+                  "false_easting", "false_northing",
+                  "standard_parallel2"]
+        punits = ["", "", "", "", "", ""]
+        pvalues = [-20., 175., 13., 8., 0., 20.]
+        cmor.set_crs(grid_id=grid_id,
+                     mapping_name=mapnm,
+                     parameter_names=params,
+                     parameter_values=pvalues,
+                     parameter_units=punits,
+                     crs_wkt=crs_wkt)
+
+        cmor.set_table(lmon_table)
+
+        axis_ids.append(cmor.axis(table_entry='time',
+                            units='months since 1980'))
+        pass_axes = [axis_ids[3], axis_ids[2]]
+
+        ivar = cmor.variable(table_entry='baresoilFrac',
+                             units='',
+                             axis_ids=pass_axes,
+                             history='no history',
+                             comment='no future'
+                             )
+
+        ntimes = 2
+        for i in range(ntimes):
+            data2d = read_2d_input_files(i, varin2d[0], lat, lon) * 1.E-6
+            cmor.write(ivar, data2d, 1, time_vals=Time[i],
+                    time_bnds=bnds_time[2 * i:2 * i + 2])
+
+        filename = cmor.close(ivar, file_name=True)
+
+        return filename
+
+
+    def test_crs_without_crs_wkt(self):
+        ds = Dataset(self.make_crs_file())
+
+        self.assertTrue('crs' in ds.variables)
+        attrs = ds.variables['crs'].ncattrs()
+        test_attrs = {
+            'grid_mapping_name': 'lambert_conformal_conic',
+            'standard_parallel': numpy.asarray([-20., 20.]),
+            'longitude_of_central_meridian': 175.0,
+            'latitude_of_projection_origin': 13.0,
+            'false_easting': 8.0,
+            'false_northing': 0.0
+        }
+
+        for attr, val in test_attrs.items():
+            self.assertTrue(attr in attrs)
+            attr_val = ds.variables['crs'].getncattr(attr)
+            if attr == 'standard_parallel':
+                self.assertTrue(numpy.array_equal(val, attr_val))
+            else:
+                self.assertEqual(val, attr_val)
+
+        self.assertTrue('crs_wkt' not in attrs)
+        
+        ds.close()
+
+
+    def test_crs_with_crs_wkt(self):
+        crs_wkt = "Text for the CRS WKT"
+        ds = Dataset(self.make_crs_file(crs_wkt))
+
+        self.assertTrue('crs' in ds.variables)
+        attrs = ds.variables['crs'].ncattrs()
+        test_attrs = {
+            'grid_mapping_name': 'lambert_conformal_conic',
+            'standard_parallel': numpy.asarray([-20., 20.]),
+            'longitude_of_central_meridian': 175.0,
+            'latitude_of_projection_origin': 13.0,
+            'false_easting': 8.0,
+            'false_northing': 0.0,
+            'crs_wkt': crs_wkt
+        }
+
+        for attr, val in test_attrs.items():
+            self.assertTrue(attr in attrs)
+            attr_val = ds.variables['crs'].getncattr(attr)
+            if attr == 'standard_parallel':
+                self.assertTrue(numpy.array_equal(val, attr_val))
+            else:
+                self.assertEqual(val, attr_val)
+        
+        ds.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Test/test_cmor_crs.py
+++ b/Test/test_cmor_crs.py
@@ -170,14 +170,14 @@ class TestLatLonGridMapping(unittest.TestCase):
             'crs_wkt': crs_wkt
             }
         
-        param_names = ['longitude_of_prime_meridian',
-                       'semi_major_axis',
-                       'long_name',
-                       'inverse_flattening',
-                       'GeoTransform',
-                       'crs_wkt']
-        param_values = [crs_params[n] for n in param_names]
-        param_units = ["" for n in param_names]
+        grid_params = {
+            'longitude_of_prime_meridian': [np.float64(0.0), "degrees_east"],
+            'semi_major_axis': {"value": np.float64(6378137.0), "units": "meters"},
+            'long_name': 'WGS 84',
+            'inverse_flattening': (np.float64(298.257223563), ""),
+            'GeoTransform': '-179.5 0.1 0 74.5 0.1',
+            'crs_wkt': crs_wkt
+            }
 
         cmor.setup(inpath='cmip6-cmor-tables/Tables',
                    netcdf_file_action=cmor.CMOR_REPLACE)
@@ -227,9 +227,7 @@ class TestLatLonGridMapping(unittest.TestCase):
         axis_ids.append(grid_id)
         cmor.set_crs(grid_id=grid_id,
                      mapping_name=crs_params['grid_mapping_name'],
-                     parameter_names=param_names,
-                     parameter_values=param_values,
-                     parameter_units=param_units)
+                     parameter_names=grid_params)
 
         cmor.set_table(lmon_table)
 

--- a/Test/test_python_CMIP6_projections.py
+++ b/Test/test_python_CMIP6_projections.py
@@ -98,7 +98,7 @@ class TestCase(unittest.TestCase):
         #    mapnm = 'polar_stereographic'
         param_dict = {
             'latitude_of_projection_origin': [90.0, 'degrees_north'],
-            'straight_vertical_longitude_from_pole': [135.0, 'degrees_east'],
+            'longitude_of_projection_origin': [135.0, 'degrees_east'],
             'standard_parallel': [70.0, 'degrees_north'],
             'false_northing': [0.0, 'meters'],
             'false_easting': [0.0, 'meters']

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -362,6 +362,7 @@ typedef struct cmor_grid_ {
 /*      for lon/lat/blon/blat/area/volumes                              */
 /* -------------------------------------------------------------------- */
     int associated_variables[6];
+    char *crs_wkt;
 } cmor_grid_t;
 
 extern cmor_grid_t cmor_grids[CMOR_MAX_GRIDS];

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -344,6 +344,7 @@ extern char cmor_traceback_info[CMOR_MAX_STRING];
 
 typedef struct cmor_grid_ {
     int id;
+    char name[CMOR_MAX_STRING];
     char mapping[CMOR_MAX_STRING];
     int nattributes;
     char attributes_names[CMOR_MAX_GRID_ATTRIBUTES][CMOR_MAX_STRING];

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -362,7 +362,9 @@ typedef struct cmor_grid_ {
 /*      for lon/lat/blon/blat/area/volumes                              */
 /* -------------------------------------------------------------------- */
     int associated_variables[6];
-    char *crs_wkt;
+    int ntextattributes;
+    char *text_attributes_names[CMOR_MAX_GRID_ATTRIBUTES];
+    char *text_attributes_values[CMOR_MAX_GRID_ATTRIBUTES];
 } cmor_grid_t;
 
 extern cmor_grid_t cmor_grids[CMOR_MAX_GRIDS];

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -363,7 +363,7 @@ typedef struct cmor_grid_ {
 /* -------------------------------------------------------------------- */
     int associated_variables[6];
     int ntextattributes;
-    char *text_attributes_names[CMOR_MAX_GRID_ATTRIBUTES];
+    char text_attributes_names[CMOR_MAX_GRID_ATTRIBUTES][CMOR_MAX_STRING];
     char *text_attributes_values[CMOR_MAX_GRID_ATTRIBUTES];
 } cmor_grid_t;
 

--- a/include/cmor_func_def.h
+++ b/include/cmor_func_def.h
@@ -270,6 +270,11 @@ extern int cmor_set_grid_mapping( int gid, char *name, int nparam,
 				  double attributes_values[CMOR_MAX_GRID_ATTRIBUTES],
 				  char *units,
 				  int lnunits );
+extern int cmor_set_crs( int gid, char *grid_mapping, int nparam,
+                    char *attributes_names, int lparams,
+                    double attributes_values[CMOR_MAX_GRID_ATTRIBUTES],
+                    char *units, int lnunits,
+                    char *crs_wkt );
 extern int cmor_grid( int *grid_id, int ndims, int *axes_ids, char type,
 		      void *lat, void *lon, int nvertices, void *blat,
 		      void *blon );

--- a/include/cmor_func_def.h
+++ b/include/cmor_func_def.h
@@ -257,9 +257,9 @@ extern int cmor_get_grid_attribute( int gid, char *name, double *value );
 extern void cmor_convert_value( char *units, char *ctmp, double *tmp );
 extern int cmor_set_grid_attribute( int gid, char *name, double *value,
 				    char *units );
-extern int cmor_has_grid_text_attribute( int gid, char *name )
+extern int cmor_has_grid_text_attribute( int gid, char *name );
 extern int cmor_get_grid_text_attribute( int gid, char *name, char *value );
-extern int cmor_set_grid_text_attribute( int gid, char *name, char *value );
+extern int cmor_set_grid_text_attribute( int gid, char *name, char *value, int size );
 extern int cmor_attribute_in_list( char *name, int n,
 				   char ( *atts )[CMOR_MAX_STRING] );
 extern int cmor_grid_valid_mapping_attribute_names( char *name, int *natt,

--- a/include/cmor_func_def.h
+++ b/include/cmor_func_def.h
@@ -257,6 +257,9 @@ extern int cmor_get_grid_attribute( int gid, char *name, double *value );
 extern void cmor_convert_value( char *units, char *ctmp, double *tmp );
 extern int cmor_set_grid_attribute( int gid, char *name, double *value,
 				    char *units );
+extern int cmor_has_grid_text_attribute( int gid, char *name )
+extern int cmor_get_grid_text_attribute( int gid, char *name, char *value );
+extern int cmor_set_grid_text_attribute( int gid, char *name, char *value );
 extern int cmor_attribute_in_list( char *name, int n,
 				   char ( *atts )[CMOR_MAX_STRING] );
 extern int cmor_grid_valid_mapping_attribute_names( char *name, int *natt,
@@ -274,7 +277,9 @@ extern int cmor_set_crs( int gid, char *grid_mapping, int nparam,
                     char *attributes_names, int lparams,
                     double attributes_values[CMOR_MAX_GRID_ATTRIBUTES],
                     char *units, int lnunits,
-                    char *crs_wkt );
+                    int ntextparam, char *text_attributes_names, int ltextparams,
+                    char *text_attributes_values,
+                    int text_attributes_length[CMOR_MAX_GRID_ATTRIBUTES]);
 extern int cmor_grid( int *grid_id, int ndims, int *axes_ids, char type,
 		      void *lat, void *lon, int nvertices, void *blat,
 		      void *blon );


### PR DESCRIPTION
Resolves #774 

This PR adds the function `cmor_set_crs` to CMOR.  This function is similar to `cmor_set_grid_mapping` as it takes a grid mapping name along with other attributes to create a dimensionless variable for that grid mapping.  The difference is that the variable will be named `crs` instead of the grid mapping name, and will have the option for a text attribute named `crs_wkt`.  The `crs_wkt` attribute is added by CMOR but is not validated as a Well-known Text (WKT) string.