### PR TITLE
Only use zstandard compression if deflate is disabled and a valid compression level is provided

### DIFF
--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -801,7 +801,7 @@ void cmor_reset_variable(int var_id)
     cmor_vars[var_id].shuffle = 0;
     cmor_vars[var_id].deflate = 1;
     cmor_vars[var_id].deflate_level = 1;
-    cmor_vars[var_id].zstandard_level = 3;
+    cmor_vars[var_id].zstandard_level = -99999;
     cmor_vars[var_id].quantize_mode = NC_NOQUANTIZE;
     cmor_vars[var_id].quantize_nsd = 1;
     cmor_vars[var_id].nomissing = 1;
@@ -2142,14 +2142,9 @@ int cmor_define_zfactors_vars(int var_id, int ncid, int *nc_dim,
                         icz =
                           cmor_tables[nTableID].vars[nTableID].zstandard_level;
 
-                        if (icd != 0) {
-                            ierr |= nc_def_var_deflate(ncid, nc_zfactors[lnzfactors],
-                                                    ics, icd, icdl);
-                        } else {
-                            ierr |= nc_def_var_deflate(ncid, nc_zfactors[lnzfactors],
-                                                    ics, 0, 0);
-                            ierr |= nc_def_var_zstandard(ncid, nc_zfactors[lnzfactors],
-                                                    icz);
+                        ierr |= nc_def_var_deflate(ncid, nc_zfactors[lnzfactors], ics, icd, icdl);
+                        if (icd == 0 && (icz >= -131072 && icz <= 22)) {
+                            ierr |= nc_def_var_zstandard(ncid, nc_zfactors[lnzfactors], icz);
                         }
 
                         if (ierr != NC_NOERR) {
@@ -3932,15 +3927,11 @@ void cmor_define_dimensions(int var_id, int ncid,
                 icdl = pVar->deflate_level;
                 icz = pVar->zstandard_level;
 
-                if (icd != 0) {
-                    ierr |= nc_def_var_deflate(ncafid, nc_bnds_vars[i],
-                                            ics, icd, icdl);
-                } else {
-                    ierr |= nc_def_var_deflate(ncafid, nc_bnds_vars[i],
-                                            ics, 0, 0);
-                    ierr |= nc_def_var_zstandard(ncafid, nc_bnds_vars[i],
-                                            icz);
+                ierr |= nc_def_var_deflate(ncafid, nc_bnds_vars[i], ics, icd, icdl);
+                if (icd == 0 && (icz >= -131072 && icz <= 22)) {
+                    ierr |= nc_def_var_zstandard(ncafid, nc_bnds_vars[i], icz);
                 }
+
                 if (ierr != NC_NOERR) {
                     cmor_handle_error_var_variadic(
                         "NCError (%i: %s) defining compression\n! "
@@ -4472,15 +4463,11 @@ int cmor_grids_def(int var_id, int nGridID, int ncafid, int *nc_dim_af,
                                                                   ref_var_id].
                       zstandard_level;
 
-                    if (icd != 0) {
-                        ierr |= nc_def_var_deflate(ncafid, nc_associated_vars[i],
-                                                ics, icd, icdl);
-                    } else {
-                        ierr |= nc_def_var_deflate(ncafid, nc_associated_vars[i],
-                                                ics, 0, 0);
-                        ierr |= nc_def_var_zstandard(ncafid, nc_associated_vars[i],
-                                                icz);
+                    ierr |= nc_def_var_deflate(ncafid, nc_associated_vars[i], ics, icd, icdl);
+                    if (icd == 0 && (icz >= -131072 && icz <= 22)) {
+                        ierr |= nc_def_var_zstandard(ncafid, nc_associated_vars[i], icz);
                     }
+
                     if (ierr != NC_NOERR) {
                         cmor_handle_error_var_variadic(
                             "NetCDF Error (%i: %s) defining\n! "
@@ -5462,11 +5449,8 @@ void cmor_create_var_attributes(int var_id, int ncid, int ncafid,
             }
         }
 
-        // Only use zstandard compression if deflate is disabled
-        if (icd != 0) {
-            ierr |= nc_def_var_deflate(ncid, pVar->nc_var_id, ics, icd, icdl);
-        } else {
-            ierr |= nc_def_var_deflate(ncid, pVar->nc_var_id, ics, 0, 0);
+        ierr |= nc_def_var_deflate(ncid, pVar->nc_var_id, ics, icd, icdl);
+        if (icd == 0 && (icz >= -131072 && icz <= 22)) {
             ierr |= nc_def_var_zstandard(ncid, pVar->nc_var_id, icz);
         }
 

--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -801,7 +801,7 @@ void cmor_reset_variable(int var_id)
     cmor_vars[var_id].shuffle = 0;
     cmor_vars[var_id].deflate = 1;
     cmor_vars[var_id].deflate_level = 1;
-    cmor_vars[var_id].zstandard_level = -99999;
+    cmor_vars[var_id].zstandard_level = -999999;
     cmor_vars[var_id].quantize_mode = NC_NOQUANTIZE;
     cmor_vars[var_id].quantize_nsd = 1;
     cmor_vars[var_id].nomissing = 1;

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -1977,7 +1977,7 @@ void cmor_init_var_def(cmor_var_def_t * var, int table_id)
     var->shuffle = 0;
     var->deflate = 1;
     var->deflate_level = 1;
-    var->zstandard_level = -99999;
+    var->zstandard_level = -999999;
     var->generic_level_name[0] = '\0';
     var->branding_suffix[0] = '\0';
     var->temporal_label[0] = '\0';

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -1977,7 +1977,7 @@ void cmor_init_var_def(cmor_var_def_t * var, int table_id)
     var->shuffle = 0;
     var->deflate = 1;
     var->deflate_level = 1;
-    var->zstandard_level = 3;
+    var->zstandard_level = -99999;
     var->generic_level_name[0] = '\0';
     var->branding_suffix[0] = '\0';
     var->temporal_label[0] = '\0';


### PR DESCRIPTION
Resolves #798

CMOR by default uses deflation with a deflation level of 1.  To use zstandard compression, the user must disable deflation with `cmor_set_deflate` and then provide a valid zstandard compression level within the range [-131072, 22] using `cmor_set_zstandard`.  Performing only one of the two actions will result in no zstandard compression being applied.

Should there be a warning message for users who use out-of-range compression levels for `cmor_set_zstandard`?