### PR TITLE
Autoconf bug workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,9 @@ aliases:
 
        mamba create -y -n smithy_env -c conda-forge conda-smithy
        mamba activate smithy_env
+       cp autoconf-workaround.patch $WORKDIR/cmor-feedstock
        cd $WORKDIR/cmor-feedstock
-       git apply $HOME/autoconf-workaround.patch
+       git apply autoconf-workaround.patch
        mamba run conda smithy rerender
        
   - &conda_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ aliases:
        mamba create -y -n smithy_env -c conda-forge conda-smithy
        mamba activate smithy_env
        cd $WORKDIR/cmor-feedstock
+       git apply $HOME/autoconf-workaround.patch
        mamba run conda smithy rerender
        
   - &conda_build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -92,6 +92,7 @@ jobs:
           mamba create -y -n smithy_env -c conda-forge conda-smithy
           mamba activate smithy_env
           cd $PROJECT_DIR/cmor-feedstock
+          git apply $HOME/autoconf-workaround.patch
           mamba run conda smithy rerender
           ls -lh .ci_support/
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -91,8 +91,9 @@ jobs:
 
           mamba create -y -n smithy_env -c conda-forge conda-smithy
           mamba activate smithy_env
+          cp autoconf-workaround.patch $WORKDIR/cmor-feedstock
           cd $PROJECT_DIR/cmor-feedstock
-          git apply $HOME/autoconf-workaround.patch
+          git apply autoconf-workaround.patch
           mamba run conda smithy rerender
           ls -lh .ci_support/
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -91,7 +91,7 @@ jobs:
 
           mamba create -y -n smithy_env -c conda-forge conda-smithy
           mamba activate smithy_env
-          cp autoconf-workaround.patch $WORKDIR/cmor-feedstock
+          cp autoconf-workaround.patch $PROJECT_DIR/cmor-feedstock
           cd $PROJECT_DIR/cmor-feedstock
           git apply autoconf-workaround.patch
           mamba run conda smithy rerender

--- a/autoconf-workaround.patch
+++ b/autoconf-workaround.patch
@@ -1,0 +1,15 @@
+diff --git a/recipe/build.sh b/recipe/build.sh
+index 5fe27be..8d92b95 100644
+--- a/recipe/build.sh
++++ b/recipe/build.sh
+@@ -7,6 +7,10 @@ fi
+ # Get an updated config.sub and config.guess
+ cp $BUILD_PREFIX/share/gnuconfig/config.* .
+ 
++# set path to M4 to work around autoconf bug
++# see https://github.com/conda-forge/autoconf-feedstock/issues/41
++export M4=$(which m4)
++
+ autoconf
+ 
+ ./configure \


### PR DESCRIPTION
Applies a workaround to a bug found in conda-forge's autoconf (see https://github.com/conda-forge/autoconf-feedstock/issues/41).

The path to `m4` needs to be set within the conda environment used by `conda-build` before running `autoconf`.

```
export M4=$(which m4)
autoconf
```