### PR TITLE
Reject data containing NaNs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -234,6 +234,7 @@ test_python: python
 	env TEST_NAME=Test/test_python_branded_variable.py make test_a_python
 	env TEST_NAME=Test/test_cmor_CMIP7.py make test_a_python
 	env TEST_NAME=Test/test_cmor_crs.py make test_a_python
+	env TEST_NAME=Test/test_cmor_nan_check.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2906,14 +2906,24 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
         cmor_handle_error_variadic(
             "Invalid value(s) detected for variable '%s' "
             "(table: %s): %zu values were NaNs. "
+            "\n! "
             "First encountered NaN "
-            "was at (axis: index/value):%s",
-            CMOR_WARNING,
+            "was at (axis: index/value):%s"
+            "\n!\n! "
+            "MIP data (missing values or otherwise) must "
+            "not include \"NaN's\". Please replace all \"NaN's\" "
+            "with an acceptable actual number.\n! If you consider "
+            "the \"NaN's\" to be missing, then replace them with "
+            "the official \"missing_value\", which for CMIP "
+            "floating point numbers is 1.e20.",
+            CMOR_CRITICAL,
             avar->id,
             cmor_tables[avar->ref_table_id].szTable_id,
             n_nan, msg_nan);
 
         free(msg_nan);
+        cmor_pop_traceback();
+        return (1);
 
     }
     if (n_lower_min != 0) {

--- a/Test/test_cmor_nan_check.py
+++ b/Test/test_cmor_nan_check.py
@@ -1,0 +1,52 @@
+import cmor
+import numpy
+import unittest
+from base_CMIP6_CV import BaseCVsTest
+
+
+def run():
+    unittest.main()
+
+
+class TestNaNCheck(BaseCVsTest):
+
+    def test_nan_check(self):
+        cmor.setup(inpath='Tables',
+                   netcdf_file_action=cmor.CMOR_REPLACE_4,
+                   logfile=self.tmpfile)
+
+        cmor.dataset_json("Test/CMOR_input_example.json")    
+        cmor.load_table("CMIP6_Amon.json")
+
+        itime = cmor.axis(table_entry= 'time',
+                        units= 'days since 2000-01-01 00:00:00',
+                        coord_vals= [15, 45, 75],
+                        cell_bounds= [0, 30, 60, 90])
+        ilat = cmor.axis(table_entry= 'latitude',
+                        units= 'degrees_north',
+                        coord_vals= [0],
+                        cell_bounds= [-1, 1])
+        ilon = cmor.axis(table_entry= 'longitude',
+                        units= 'degrees_east',
+                        coord_vals= [90],
+                        cell_bounds= [89, 91])
+
+        axis_ids = [itime,ilat,ilon]
+                    
+        varid = cmor.variable('ts', 'K', axis_ids)
+
+        with self.assertRaises(cmor.CMORError):
+            _ = cmor.write(varid, [273, numpy.nan, 273])
+        
+        self.assertCV(
+            "Invalid value(s) detected for variable 'ts' "
+            "(table: Amon): 1 values were NaNs."
+        )
+        self.assertCV(
+            "time: 1/45 lat: 0/0 lon: 0/90",
+            line_trigger="First encountered NaN was at (axis: index/value):"
+        )
+
+
+if __name__ == '__main__':
+    run()

--- a/Test/test_python_cfmip_site_axis_test.py
+++ b/Test/test_python_cfmip_site_axis_test.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     print('ok: created variable for "cl"')
 
     ofact_id = cmor.zfactor(zaxis_id, 'orog', 'm', [gaxis_id], 'd',
-                            zfactor_values=[123.0])
+                            zfactor_values=[123.0, 123.0, 123.0])
     print('ok: created orog zfactors')
     # Write some data to this variable. First convert raw data to numpy arrays.
     shape = (1, 3, 1)


### PR DESCRIPTION
Resolves #802 

If variable data or zfactor data contains NaN values, then `cmor_write` will throw an error with the following message.

```
C Traceback:
! In function: cmor_write_var_to_file
! called from: cmor_create_var_attributes
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: Invalid value(s) detected for variable 'orog' (table: CFsubhr): 1 values were NaNs. 
! First encountered NaN was at (axis: index/value): site: 2/3
!
! MIP data (missing values or otherwise) must not include "NaN's". Please replace all "NaN's" with an acceptable actual number.
! If you consider the "NaN's" to be missing, then replace them with the official "missing_value", which for CMIP floating point numbers is 1.e20.
!
!!!!!!!!!!!!!!!!!!!!!!!!!
```