### PR TITLE
Catch unsupported CF calendars as errors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -235,6 +235,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_CMIP7.py make test_a_python
 	env TEST_NAME=Test/test_cmor_crs.py make test_a_python
 	env TEST_NAME=Test/test_cmor_nan_check.py make test_a_python
+	env TEST_NAME=Test/test_cmor_unsupported_calendar.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -8,9 +8,11 @@
 
 int cuErrOpts = CU_VERBOSE;
 
-/************************************************************************/
-/*                         cmor_calendar_c2i()                          */
-/************************************************************************/
+/*****************************************************************************/
+/*                         cmor_calendar_c2i()                               */
+/* This function recognizes all valid calendars in the CF 1.12 release       */
+/* See https://cfconventions.org/cf-conventions/cf-conventions.html#calendar */
+/*****************************************************************************/
 int cmor_calendar_c2i(char *calendar, cdCalenType * ical)
 {
 
@@ -39,10 +41,13 @@ int cmor_calendar_c2i(char *calendar, cdCalenType * ical)
             || strcmp(calendar, "all_leap") == 0
             || strcmp(calendar, "366_day") == 0) {
         cmor_handle_error_variadic(
-            "A %s calendar is not currently an option for MIP results."
+            "A %s calendar is an invalid selection for Model Intercomparison Project (MIP) data."
             "\n! "
-            "Please adopt a different, more common calendar used for "
-            "climate studies", CMOR_NORMAL, calendar);
+            "Please adopt a different, more common calendar used for climate studies. "
+            "\n!\n! "
+            "This function recognizes all valid calendars in the CF 1.12 release. "
+            "See https://cfconventions.org/cf-conventions/cf-conventions.html#calendar",
+            CMOR_NORMAL, calendar);
         cmor_pop_traceback();
         return (1);
     } else {

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -34,7 +34,18 @@ int cmor_calendar_c2i(char *calendar, cdCalenType * ical)
         *ical = cdJulian;
     else if (strcmp(calendar, "none") == 0)
         *ical = cdClim;
-    else {
+    else if (strcmp(calendar, "utc") == 0
+            || strcmp(calendar, "tai") == 0
+            || strcmp(calendar, "all_leap") == 0
+            || strcmp(calendar, "366_day") == 0) {
+        cmor_handle_error_variadic(
+            "A %s calendar is not currently an option for MIP results."
+            "\n! "
+            "Please adopt a different, more common calendar used for "
+            "climate studies", CMOR_NORMAL, calendar);
+        cmor_pop_traceback();
+        return (1);
+    } else {
         cmor_pop_traceback();
         return (1);
     }

--- a/Test/test_cmor_unsupported_calendar.py
+++ b/Test/test_cmor_unsupported_calendar.py
@@ -1,0 +1,28 @@
+import cmor
+import numpy
+import unittest
+from base_CMIP6_CV import BaseCVsTest
+
+
+class TestUnsupportedCalendar(BaseCVsTest):
+
+    def test_unsupported_calendar(self):
+
+        cmor.setup(inpath='Tables',
+                    netcdf_file_action=cmor.CMOR_REPLACE, 
+                    logfile=self.tmpfile)
+        cmor.dataset_json("Test/CMOR_input_example.json")
+        cmor.set_cur_dataset_attribute("calendar", "366_day")
+
+        cmor.load_table("CMIP6_Omon.json")
+
+        with self.assertRaises(cmor.CMORError):
+            _ = cmor.axis(table_entry="time", units='months since 2010',
+                          coord_vals=numpy.array([0, 1, 2, 3, 4.]),
+                          cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
+
+        self.assertCV('A 366_day calendar is not currently an option for MIP results.')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Test/test_cmor_unsupported_calendar.py
+++ b/Test/test_cmor_unsupported_calendar.py
@@ -9,7 +9,7 @@ class TestUnsupportedCalendar(BaseCVsTest):
     def test_unsupported_calendar(self):
 
         cmor.setup(inpath='Tables',
-                    netcdf_file_action=cmor.CMOR_REPLACE, 
+                    netcdf_file_action=cmor.CMOR_REPLACE,
                     logfile=self.tmpfile)
         cmor.dataset_json("Test/CMOR_input_example.json")
         cmor.set_cur_dataset_attribute("calendar", "366_day")
@@ -21,7 +21,8 @@ class TestUnsupportedCalendar(BaseCVsTest):
                           coord_vals=numpy.array([0, 1, 2, 3, 4.]),
                           cell_bounds=numpy.array([0, 1, 2, 3, 4, 5.]))
 
-        self.assertCV('A 366_day calendar is not currently an option for MIP results.')
+        self.assertCV(("A 366_day calendar is an invalid selection for "
+                       "Model Intercomparison Project (MIP) data."))
 
 
 if __name__ == '__main__':

--- a/compile_line.txt.in
+++ b/compile_line.txt.in
@@ -3,4 +3,4 @@
  @CC@ @DEBUG@ @MACROS@ @CFLAGS@ @CPPFLAGS@  mycode.c -L@prefix@/lib -I@prefix@/include  -L. -lcmor @NCCFLAGS@ @NCLDFLAGS@ @UDUNITS2LDFLAGS@ @UDUNITS2FLAGS@ @JSONCLDFLAGS@ @JSONCFLAGS@ @UUIDLDFLAGS@ @UUIDFLAGS@ @LDFLAGS@ -o mycode
 
 # The following line will compile "FORTRAN" code mycode.f90 with cmor, additional libraries mycode.f90 may requires should be added to this line
-@FC@ @DEBUG@ @FCFLAGS@ mycode.f90 -L@prefix@/lib -L. -lcmor @NCCFLAGS@ @NCLDFLAGS@ @UDUNITS2LDFLAGS@ @UDUNITS2FLAGS@ @JSONCLDFLAGS@ @JSONCFLAGS@ @UUIDLDFLAGS@ @UUIDFLAGS@ @ZFLAGS@ @ZLDFLAG@ -o mycode
+@FC@ @DEBUG@ @FCFLAGS@ mycode.f90 -L@prefix@/lib -L. -lcmor @NCCFLAGS@ @NCLDFLAGS@ @UDUNITS2LDFLAGS@ @UDUNITS2FLAGS@ @JSONCLDFLAGS@ @JSONCFLAGS@ @UUIDLDFLAGS@ @UUIDFLAGS@ @ZFLAGS@ @ZLDFLAGS@ -o mycode


### PR DESCRIPTION
Resolves #813 

If a CF calendar name that is unsupported by CMOR is used for the attribute `calendar`, then CMOR will throw an error.

```
C Traceback:
! In function: cmor_calendar_c2i
! called from: cmor_close_variable
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Error: A utc calendar is not currently an option for MIP results.
! Please adopt a different, more common calendar used for climate studies
!
!!!!!!!!!!!!!!!!!!!!!!!!!
```