### PR TITLE
Get mip_era for title from global attributes instead of the table header

### DIFF
--- a/Src/cmor.c
+++ b/Src/cmor.c
@@ -3052,25 +3052,7 @@ int cmor_setGblAttr(int var_id)
     }
     ctmp[32] = '\0';
     strcat(msg, ctmp);
-
     cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_TABLE_INFO, msg, 0);
-
-    if (cmor_has_cur_dataset_attribute(GLOBAL_ATT_SOURCE_ID) == 0) {
-        cmor_get_cur_dataset_attribute(GLOBAL_ATT_SOURCE_ID, ctmp);
-    } else {
-        ctmp[0] = '\0';
-    }
-/* -------------------------------------------------------------------- */
-/*    Set attribute Title for netCDF file (CMIP6)                       */
-/* -------------------------------------------------------------------- */
-    snprintf(msg, CMOR_MAX_STRING, GLOBAL_ATT_TITLE_MSG, ctmp,
-             cmor_tables[nVarRefTblID].mip_era);
-/* -------------------------------------------------------------------- */
-/*    Change Title if not provided by user.                             */
-/* -------------------------------------------------------------------- */
-    if (cmor_has_cur_dataset_attribute(GLOBAL_ATT_TITLE) != 0) {
-        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_TITLE, msg, 0);
-    }
 /* -------------------------------------------------------------------- */
 /*     check source and model_id are identical                          */
 /* -------------------------------------------------------------------- */
@@ -3079,7 +3061,26 @@ int cmor_setGblAttr(int var_id)
                                                 cmor_tables
                                                 [nVarRefTblID].mip_era, 0);
     }
-
+/* -------------------------------------------------------------------- */
+/*    Set attribute Title for netCDF file (CMIP6)                       */
+/* -------------------------------------------------------------------- */
+    if (cmor_has_cur_dataset_attribute(GLOBAL_ATT_SOURCE_ID) == 0) {
+        cmor_get_cur_dataset_attribute(GLOBAL_ATT_SOURCE_ID, ctmp);
+    } else {
+        ctmp[0] = '\0';
+    }
+    if (cmor_has_cur_dataset_attribute(GLOBAL_ATT_MIP_ERA) == 0) {
+        cmor_get_cur_dataset_attribute(GLOBAL_ATT_MIP_ERA, ctmp2);
+    } else {
+        ctmp2[0] = '\0';
+    }
+    snprintf(msg, CMOR_MAX_STRING, GLOBAL_ATT_TITLE_MSG, ctmp, ctmp2);
+/* -------------------------------------------------------------------- */
+/*    Change Title if not provided by user.                             */
+/* -------------------------------------------------------------------- */
+    if (cmor_has_cur_dataset_attribute(GLOBAL_ATT_TITLE) != 0) {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_TITLE, msg, 0);
+    }
 /* -------------------------------------------------------------------- */
 /*      first check if the variable itself has a realm                  */
 /* -------------------------------------------------------------------- */

--- a/Test/test_cmor_CMIP6Plus.py
+++ b/Test/test_cmor_CMIP6Plus.py
@@ -47,11 +47,15 @@ class TestCMIP6Plus(unittest.TestCase):
         self.assertEqual(
             cmor.write(ivar, data, ntimes_passed=ntimes_passed),
             0)
-        
+
         self.assertFalse(cmor.has_cur_dataset_attribute('further_info_url'))
-        
+
         realms = cmor.get_cur_dataset_attribute('realm')
         self.assertEqual(realms, "ocean seaIce")
+
+        title = cmor.get_cur_dataset_attribute('title')
+        self.assertEqual(title,
+                         'HadGEM3-GC31-LL output prepared for CMIP6Plus')
 
         self.assertEqual(cmor.close(), 0)
 


### PR DESCRIPTION
Fixes #776 

This resolves the issue of the `mip_era` missing from the `title` attribute by getting the `mip_era` from the file's global attributes instead of from the variable table header.