### PR TITLE
Check user-defined required attributes before checking all required attributes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -238,6 +238,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_unsupported_calendar.py make test_a_python
 	env TEST_NAME=Test/test_cmor_time_interval_check.py make test_a_python
 	env TEST_NAME=Test/test_cmor_license_attributes.py make test_a_python
+	env TEST_NAME=Test/test_cmor_nested_cv_attribute.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2467,6 +2467,18 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
     cmor_add_traceback("_CV_checkGblAttributes");
     required_attrs = cmor_CV_rootsearch(CV, CV_KEY_REQUIRED_GBL_ATTRS);
     if (required_attrs != NULL) {
+        // First, validate required attributes that are set by the user.
+        // This will also set attributes that are dependent on other
+        // attributes such as `source` when `source_id` is set.
+        for (i = 0; i < required_attrs->anElements; i++) {
+            rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
+            if (rc != 0) {
+                bCriticalError = 1;
+                ierr += -1;
+            }
+        }
+        // Check that all required attributes are set, including those set by 
+        // cmor_CV_ValidateAttribute in the above loop.
         for (i = 0; i < required_attrs->anElements; i++) {
             rc = cmor_has_cur_dataset_attribute(required_attrs->aszValue[i]);
             if (rc != 0) {
@@ -2476,11 +2488,6 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
                          "attribute was not properly set.\n! \n! "
                          "Please set attribute: \"%s\" in your input file.",
                          CMOR_NORMAL, required_attrs->aszValue[i]);
-                bCriticalError = 1;
-                ierr += -1;
-            }
-            rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
-            if (rc != 0) {
                 bCriticalError = 1;
                 ierr += -1;
             }

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2471,10 +2471,12 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
         // This will also set attributes that are dependent on other
         // attributes such as `source` when `source_id` is set.
         for (i = 0; i < required_attrs->anElements; i++) {
-            rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
-            if (rc != 0) {
-                bCriticalError = 1;
-                ierr += -1;
+            if (cmor_has_cur_dataset_attribute(required_attrs->aszValue[i]) == 0) {
+                rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
+                if (rc != 0) {
+                    bCriticalError = 1;
+                    ierr += -1;
+                }
             }
         }
         // Check that all required attributes are set, including those set by 
@@ -2488,6 +2490,11 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
                          "attribute was not properly set.\n! \n! "
                          "Please set attribute: \"%s\" in your input file.",
                          CMOR_NORMAL, required_attrs->aszValue[i]);
+                bCriticalError = 1;
+                ierr += -1;
+            }
+            rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);
+            if (rc != 0) {
                 bCriticalError = 1;
                 ierr += -1;
             }

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -2468,8 +2468,8 @@ int cmor_CV_checkGblAttributes(cmor_CV_def_t * CV)
     required_attrs = cmor_CV_rootsearch(CV, CV_KEY_REQUIRED_GBL_ATTRS);
     if (required_attrs != NULL) {
         // First, validate required attributes that are set by the user.
-        // This will also set attributes that are dependent on other
-        // attributes such as `source` when `source_id` is set.
+        // This will also set any attributes in the controlled vocabulary
+        // that are dependent on user input and only have one value.
         for (i = 0; i < required_attrs->anElements; i++) {
             if (cmor_has_cur_dataset_attribute(required_attrs->aszValue[i]) == 0) {
                 rc = cmor_CV_ValidateAttribute(CV, required_attrs->aszValue[i]);

--- a/Test/test_cmor_nested_cv_attribute.py
+++ b/Test/test_cmor_nested_cv_attribute.py
@@ -1,0 +1,108 @@
+import json
+import cmor
+import unittest
+import os
+
+from netCDF4 import Dataset
+
+CV_PATH = "TestTables/CMIP6_CV_nested_attribute.json"
+
+DATASET_INFO = {
+    "_AXIS_ENTRY_FILE": "Tables/CMIP6_coordinate.json",
+    "_FORMULA_VAR_FILE": "Tables/CMIP6_formula_terms.json",
+    "_controlled_vocabulary_file": CV_PATH,
+    "activity_id": "CMIP",
+    "branch_method": "standard",
+    "branch_time_in_child": 30.0,
+    "branch_time_in_parent": 10800.0,
+    "calendar": "360_day",
+    "cv_version": "6.2.19.0",
+    "domain_id": "EUR-50",
+    "experiment": "AMIP",
+    "experiment_id": "amip",
+    "forcing_index": "3",
+    "further_info_url": "https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-LL.amip.none.r1i1p1f3",
+    "grid": "N96",
+    "grid_label": "gn",
+    "initialization_index": "1",
+    "institution": "Met Office Hadley Centre, Fitzroy Road, Exeter, Devon, EX1 3PB, UK",
+    "institution_id": "MOHC",
+    "license": "CMIP6 model data produced by the Met Office Hadley Centre is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https://ukesm.ac.uk/cmip6. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
+    "mip_era": "CMIP6",
+    "nominal_resolution": "250 km",
+    "outpath": ".",
+    "parent_activity_id": "no parent",
+    "physics_index": "1",
+    "realization_index": "1",
+    "source": "HadGEM3-GC31-LL (2016): \naerosol: UKCA-GLOMAP-mode\natmos: MetUM-HadGEM3-GA7.1 (N96; 192 x 144 longitude/latitude; 85 levels; top level 85 km)\natmosChem: none\nland: JULES-HadGEM3-GL7.1\nlandIce: none\nocean: NEMO-HadGEM3-GO6.0 (eORCA1 tripolar primarily 1 deg with meridional refinement down to 1/3 degree in the tropics; 360 x 330 longitude/latitude; 75 levels; top grid cell 0-1 m)\nocnBgchem: none\nseaIce: CICE-HadGEM3-GSI8 (eORCA1 tripolar primarily 1 deg; 360 x 330 longitude/latitude)",
+    "source_id": "HadGEM3-GC31-LL",
+    "source_type": "AGCM",
+    "sub_experiment": "none",
+    "sub_experiment_id": "none",
+    "tracking_prefix": "hdl:21.14100",
+    "variant_label": "r1i1p1f3"
+}
+
+
+class TestNestedCVAttribute(unittest.TestCase):
+    def setUp(self):
+        """
+        Write out a simple file using CMOR
+        """
+        # Set up CMOR
+        cmor.setup(inpath="Tables", netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile="cmor.log", create_subdirectories=0)
+
+        # Add 'domain' and 'domain_id' to required attributes of CV
+        # and 'domain_id' nested attribute
+        with open("Tables/CMIP6_CV.json", "r") as cv_infile:
+            cv = json.load(cv_infile)
+            cv["CV"]["required_global_attributes"].append("domain")
+            cv["CV"]["required_global_attributes"].append("domain_id")
+            cv["CV"]["required_global_attributes"].sort()
+            domain_id = {
+                "EUR-50": {
+                    "domain": "Europe",
+                    "domain_id": "EUR-50"
+                }
+            }
+            cv["CV"]["domain_id"] = domain_id
+            with open(CV_PATH, "w") as cv_outfile:
+                json.dump(cv, cv_outfile, sort_keys=True, indent=4)
+
+        # Define dataset using DATASET_INFO
+        with open("Test/input_nested_attribute.json", "w") as input_file:
+            json.dump(DATASET_INFO, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json("Test/input_nested_attribute.json")
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+    def test_nested_cv_variable(self):
+        mip_table = "CMIP6_Omon.json"
+        _ = cmor.load_table(mip_table)
+
+        itim = cmor.axis(
+            table_entry='time',
+            units='months since 2010-1-1',
+            coord_vals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            cell_bounds=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        ivar = cmor.variable('thetaoga', units='deg_C', axis_ids=[itim, ])
+
+        data = [280., ] * 12
+        cmor.write(ivar, data)
+        filename = cmor.close(ivar, file_name=True)
+
+        ds = Dataset(filename)
+        attrs = ds.ncattrs()
+        self.assertTrue('domain' in attrs)
+        self.assertTrue('domain_id' in attrs)
+        self.assertEqual('Europe', ds.getncattr('domain'))
+        self.assertEqual('EUR-50', ds.getncattr('domain_id'))
+        ds.close()
+        os.remove(filename)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Test/test_cmor_nested_cv_attribute.py
+++ b/Test/test_cmor_nested_cv_attribute.py
@@ -79,7 +79,7 @@ class TestNestedCVAttribute(unittest.TestCase):
         if error_flag:
             raise RuntimeError("CMOR dataset_json call failed")
 
-    def test_nested_cv_variable(self):
+    def test_nested_cv_attribute(self):
         mip_table = "CMIP6_Omon.json"
         _ = cmor.load_table(mip_table)
 


### PR DESCRIPTION
Resolves #737

CMOR will now check the required attributes set by the user first before checking all required attributes listed in `required_global_attributes` in the CV. This allows for the setting of attributes nested within attributes such as the `domain_id` example in https://github.com/PCMDI/cmor/issues/737#issue-2240078052. In that example, `domain_id` will be validated first to allow the setting of the `domain` attribute. A second validation pass will then validate the `domain` attribute.