### PR TITLE
Use directory path and file name template in DRS section of CV

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -239,6 +239,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_time_interval_check.py make test_a_python
 	env TEST_NAME=Test/test_cmor_license_attributes.py make test_a_python
 	env TEST_NAME=Test/test_cmor_nested_cv_attribute.py make test_a_python
+	env TEST_NAME=Test/test_cmor_path_and_file_templates.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/_controlvocabulary.c
+++ b/Src/_controlvocabulary.c
@@ -429,9 +429,11 @@ static PyObject *PyCMOR_setup(PyObject * self, PyObject * args)
     }
     strncpytrim(cmor_current_dataset.path_template,
                 CMOR_DEFAULT_PATH_TEMPLATE, CMOR_MAX_STRING);
+    cmor_current_dataset.default_path_template = 1;
 
     strncpytrim(cmor_current_dataset.file_template,
                 CMOR_DEFAULT_FILE_TEMPLATE, CMOR_MAX_STRING);
+    cmor_current_dataset.default_file_template = 1;
 
     strncpytrim(cmor_current_dataset.furtherinfourl,
                 CMOR_DEFAULT_FURTHERURL_TEMPLATE, CMOR_MAX_STRING);

--- a/Test/test_cmor_path_and_file_templates.py
+++ b/Test/test_cmor_path_and_file_templates.py
@@ -1,0 +1,216 @@
+import json
+import cmor
+import unittest
+import os
+import numpy
+
+CV_PATH = "TestTables/CMIP7_CV_DRS.json"
+
+DATASET_INFO = {
+    "_AXIS_ENTRY_FILE": "Tables/CMIP6_coordinate.json",
+    "_FORMULA_VAR_FILE": "Tables/CMIP6_formula_terms.json",
+    "_cmip7_option": 1,
+    "_controlled_vocabulary_file": CV_PATH,
+    "activity_id": "CMIP",
+    "branch_method": "standard",
+    "branch_time_in_child": 30.0,
+    "branch_time_in_parent": 10800.0,
+    "calendar": "360_day",
+    "cv_version": "6.2.19.0",
+    "experiment": "1 percent per year increase in CO2",
+    "experiment_id": "1pctCO2",
+    "forcing_index": "3",
+    "grid": "N96",
+    "grid_label": "gn",
+    "initialization_index": "1",
+    "institution_id": "PCMDI",
+    "license_id": "CC BY 4.0",
+    "nominal_resolution": "250 km",
+    "outpath": ".",
+    "parent_mip_era": "CMIP7",
+    "parent_time_units": "days since 1850-01-01",
+    "parent_activity_id": "CMIP",
+    "parent_source_id": "PCMDI-test-1-0",
+    "parent_experiment_id": "piControl",
+    "parent_variant_label": "r1i1p1f3",
+    "physics_index": "1",
+    "realization_index": "9",
+    "source_id": "PCMDI-test-1-0",
+    "source_type": "AOGCM CHEM BGC",
+    "tracking_prefix": "hdl:21.14100",
+    "host_collection": "CMIP7",
+    "frequency": "mon",
+    "region": "glb",
+    "archive_id": "WCRP"
+}
+
+
+class TestPathAndFileTemplates(unittest.TestCase):
+
+    def gen_cmor_file(self):
+        tos = numpy.array([27, 27, 27, 27,
+                           27, 27, 27, 27,
+                           27, 27, 27, 27,
+                           27, 27, 27, 27,
+                           27, 27, 27, 27,
+                           27, 27, 27, 27
+                           ])
+        tos.shape = (2, 3, 4)
+        lat = numpy.array([10, 20, 30])
+        lat_bnds = numpy.array([5, 15, 25, 35])
+        lon = numpy.array([0, 90, 180, 270])
+        lon_bnds = numpy.array([-45, 45,
+                                135,
+                                225,
+                                315
+                                ])
+        time = numpy.array([15.5, 45])
+        time_bnds = numpy.array([0, 31, 60])
+        cmor.load_table("CMIP7_ocean2d.json")
+        cmorlat = cmor.axis("latitude",
+                            coord_vals=lat,
+                            cell_bounds=lat_bnds,
+                            units="degrees_north")
+        cmorlon = cmor.axis("longitude",
+                            coord_vals=lon,
+                            cell_bounds=lon_bnds,
+                            units="degrees_east")
+        cmortime = cmor.axis("time",
+                             coord_vals=time,
+                             cell_bounds=time_bnds,
+                             units="days since 2018")
+        axes = [cmortime, cmorlat, cmorlon]
+        cmortos = cmor.variable("tos_tavg-u-hxy-sea", "degC", axes)
+        self.assertEqual(cmor.write(cmortos, tos), 0)
+        version = cmor.get_cur_dataset_attribute('_version')
+        filepath = cmor.close(cmortos, file_name=True)
+
+        # Attributes for reconstructing file path
+        attrs = DATASET_INFO.copy()
+        variant_label = ('r{realization_index}i{initialization_index}'
+                         'p{physics_index}f{forcing_index}').format(**attrs)
+        attrs['mip_era'] = 'CMIP7'
+        attrs['table_id'] = 'ocean2d'
+        attrs['variable_id'] = 'tos'
+        attrs['version'] = version
+        attrs['variant_label'] = variant_label
+        attrs['branding_suffix'] = 'tavg-u-hxy-sea'
+
+        return (filepath, attrs)
+
+    def test_default_path_and_file_templates(self):
+        # Set up CMOR
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE)
+
+        # Remove "DRS" section from CV to use default
+        # directory path and file name templates in CMOR
+        with open("TestTables/CMIP7_CV.json", "r") as cv_infile:
+            cv = json.load(cv_infile)
+            cv["CV"].pop("DRS")
+            with open(CV_PATH, "w") as cv_outfile:
+                json.dump(cv, cv_outfile, sort_keys=True, indent=4)
+
+        # Define dataset using DATASET_INFO
+        with open("Test/input_drs.json", "w") as input_file:
+            json.dump(DATASET_INFO, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json("Test/input_drs.json")
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+        filepath, attrs = self.gen_cmor_file()
+
+        predicted_path = ('./{mip_era}/{activity_id}/{institution_id}/'
+                          '{source_id}/{experiment_id}/{variant_label}/'
+                          '{table_id}/{variable_id}/{grid_label}/{version}'
+                          ).format(**attrs)
+        predicted_file = ('{variable_id}_{table_id}_{source_id}_'
+                          '{experiment_id}_{variant_label}_{grid_label}_'
+                          '201801-201802.nc').format(**attrs)
+        predicted_filepath = os.path.join(predicted_path, predicted_file)
+        self.assertEqual(filepath, predicted_filepath)
+
+        os.remove(filepath)
+        os.remove(CV_PATH)
+
+    def test_cv_path_and_file_templates(self):
+        # Set up CMOR
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE)
+
+        # Use "DRS" section from CV
+        with open("TestTables/CMIP7_CV.json", "r") as cv_infile:
+            cv = json.load(cv_infile)
+            with open(CV_PATH, "w") as cv_outfile:
+                json.dump(cv, cv_outfile, sort_keys=True, indent=4)
+
+        # Define dataset using DATASET_INFO
+        with open("Test/input_drs.json", "w") as input_file:
+            json.dump(DATASET_INFO, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json("Test/input_drs.json")
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+        filepath, attrs = self.gen_cmor_file()
+
+        predicted_path = ('./{mip_era}/{activity_id}/{source_id}/{region}/'
+                          '{frequency}/{experiment_id}/{variant_label}/'
+                          '{variable_id}/{branding_suffix}/{grid_label}/'
+                          '{version}/').format(**attrs)
+        predicted_file = ('{variable_id}_{branding_suffix}_{frequency}_'
+                          '{region}_{grid_label}_{source_id}_{experiment_id}_'
+                          '{variant_label}_201801-201802.nc').format(**attrs)
+        predicted_filepath = os.path.join(predicted_path, predicted_file)
+        self.assertEqual(filepath, predicted_filepath)
+
+        os.remove(filepath)
+        os.remove(CV_PATH)
+
+    def test_user_input_path_and_file_templates(self):
+        # Set up CMOR
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE)
+
+        # Use "DRS" section from CV
+        with open("TestTables/CMIP7_CV.json", "r") as cv_infile:
+            cv = json.load(cv_infile)
+            with open(CV_PATH, "w") as cv_outfile:
+                json.dump(cv, cv_outfile, sort_keys=True, indent=4)
+
+        # Use directory path and file name templates from user input
+        with open("Test/input_drs.json", "w") as input_file:
+            user_input = DATASET_INFO.copy()
+            user_input["output_path_template"] = (
+                "<activity_id><source_id><experiment_id>"
+                "<frequency><variable_id><branding_suffix>"
+            )
+            user_input["output_file_template"] = (
+                "<region><grid_label><variant_label><version>"
+            )
+            json.dump(user_input, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json("Test/input_drs.json")
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+        filepath, attrs = self.gen_cmor_file()
+
+        predicted_path = ('./{activity_id}/{source_id}/{experiment_id}/'
+                          '{frequency}/{variable_id}/{branding_suffix}/'
+                          ).format(**attrs)
+        predicted_file = ('{region}_{grid_label}_{variant_label}_{version}'
+                          '_201801-201802.nc').format(**attrs)
+        predicted_filepath = os.path.join(predicted_path, predicted_file)
+        self.assertEqual(filepath, predicted_filepath)
+
+        os.remove(filepath)
+        os.remove(CV_PATH)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/TestTables/CMIP7_CV.json
+++ b/TestTables/CMIP7_CV.json
@@ -2,9 +2,9 @@
     "CV":{
         "DRS":{
             "directory_path_example":"CMIP7/CMIP/PCMDI-test-1-0/glb/mon/historical/r1i1p1f3/tas/tavg-h2m-hxy-u/gn/v20191207/",
-            "directory_path_template":"<mip_era><activity_id><source_id><region><frequency><experiment_id><variant_id><variable_id><branding_suffix><grid_label><version>",
+            "directory_path_template":"<mip_era><activity_id><source_id><region><frequency><experiment_id><variant_label><variable_id><branding_suffix><grid_label><version>",
             "filename_example":"tas_tavg-h2m-hxy-u_mon_glb_gn_PCMDI-test-1-0_historical_r1i1p1f3_185001-186912.nc",
-            "filename_template":"<variable_id><branding_suffix><frequency><region><grid_label><source_id><experiment_id><variant_id>[<time_range>].nc"
+            "filename_template":"<variable_id><branding_suffix><frequency><region><grid_label><source_id><experiment_id><variant_label>"
         },
         "archive_id":{
             "WCRP":"a collection of datasets from the AMIP and CMIP project phases, along with project supporting datasets from the input4MIPs (forcing datasets used to drive CMIP simulations) and obs4MIPs (observational datasets used to evaluate CMIP simulations, and numerous other supporting activities"

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -258,6 +258,9 @@
 #define CV_KEY_LICENSE_TEMPLATE       "license_template"
 #define CV_KEY_LICENSE_TYPE           "license_type"
 #define CV_KEY_LICENSE_URL            "license_url"
+#define CV_KEY_DRS                    "DRS"
+#define CV_KEY_DIR_PATH_TEMPLATE      "directory_path_template"
+#define CV_KEY_FILENAME_TEMPLATE      "filename_template"
 
 #define CV_EXP_ATTR_ADDSOURCETYPE     "additional_allowed_model_components"
 #define CV_EXP_ATTR_REQSOURCETYPE     "required_model_components"
@@ -649,6 +652,8 @@ typedef struct cmor_dataset_def_ {
     int initiated;
     int associate_file;		/*flag to store associated variables separately */
     int associated_file;	/* ncid of associated file */
+    int default_path_template; /* 1 if default path template is in use */
+    int default_file_template; /* 1 if default file name template is in use */
     char associated_file_name[CMOR_MAX_STRING];	/*associated file path */
     char tracking_id[CMOR_MAX_STRING];	/*associated tracking id */
     char path_template[CMOR_MAX_STRING]; /* <keys> for each directory */


### PR DESCRIPTION
Resolves #834 

This will allow the use of the `directory_path_template` and `filename_template` attributes in the `DRS` section of CV files.  If the user defines `output_path_template` or `output_file_template` in the input JSON, then they will overwrite the path or file template defined by the CV's DRS.  If the `DRS` section is not present or `directory_path_template` or `filename_template` are not present in the section, then CMOR's default template values will be used. 

Some changes will need to be made to the DRS template values.  In [CMIP6_CV.json](https://github.com/PCMDI/cmip6-cmor-tables/blob/5d08a879bbc79657c367098a2b84279593e63551/Tables/CMIP6_CV.json#L3621), the file name template uses the pattern `[_<time_range>]`.  There is no `time_range` attribute in CMOR.  Rather, the time range is applied by CMOR concatenated on the end of the string generated from the file name template.  Leaving `[_<time_range>]` in the template will cause it to be applied to the string. (Ex. ./CMIP7/CMIP/PCMDI-test-1-0/glb/mon/1pctCO2/r9i1p1f3/tos/tavg-u-hxy-sea/gn/v20250627/tos_tavg-u-hxy-sea_mon_glb_gn_PCMDI-test-1-0_1pctCO2_r9i1p1f3_time_range_201801-201802.nc)