### PR TITLE
Fix compiler error in _cmormodue.c

### DIFF
--- a/Src/_cmormodule.c
+++ b/Src/_cmormodule.c
@@ -936,7 +936,7 @@ static PyObject *PyCMOR_set_crs(PyObject * self, PyObject * args)
       cmor_set_crs(gid, name, n, (char *)nms,
                     CMOR_MAX_STRING, param_val,
                     (char *)units, CMOR_MAX_STRING,
-                    tn, text_nms, CMOR_MAX_STRING,
+                    tn, (char *)text_nms, CMOR_MAX_STRING,
                     text_vals, text_len);
 
     free(text_vals);


### PR DESCRIPTION
Resolves #828 

This error was fixed by casting the 2D array that holds the text parameter names as `char *` like the other arrays for parameter names and units.