### PR TITLE
Don't show warning if standard_parallel1 and standard_parallel2 are used for grid mapping/CRS

### DIFF
--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -388,6 +388,12 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
                                             char (*dims)
                                             [CMOR_MAX_STRING])
 {
+/* -------------------------------------------------------------------- */
+/*   The grid mapping attribute mappings below are consistent with      */
+/*   CF 1.12 (https://cfconventions.org/Data/cf-conventions/            */
+/*   cf-conventions-1.12/cf-conventions.html#appendix-grid-mappings)    */
+/* -------------------------------------------------------------------- */
+
     int i, j;
 
     *natt = -1;                 /* -1 means mapping name not found */

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -809,7 +809,7 @@ int cmor_set_crs(int gid, char *grid_mapping, int nparam,
     char *achar, *bchar;
     char ltext_attributes_name[CMOR_MAX_STRING];
 
-    cmor_add_traceback("cmor_set_grid_mapping");
+    cmor_add_traceback("cmor_set_crs");
 
     ierr = cmor_set_grid_mapping(gid, grid_mapping, nparam,
         attributes_names, lparams, attributes_values,

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -760,11 +760,24 @@ int cmor_set_grid_mapping(int gid, char *name, int nparam,
 
     for (i = 0; i < nattributes - 7; i++) {
         if (cmor_has_grid_attribute(gid, grid_attributes[i]) == 1) {
-            cmor_handle_error_variadic(
-                "Grid mapping attribute %s has not been set, "
-                "you should consider setting it",
-                CMOR_WARNING,
-                grid_attributes[i]);
+            if (strcmp(grid_attributes[i], "standard_parallel") == 0) {
+                if (cmor_has_grid_attribute(gid, "standard_parallel1") == 1
+                || cmor_has_grid_attribute(gid, "standard_parallel2") == 1) {
+                    cmor_handle_error_variadic(
+                        "Grid mapping attribute %s has not been set, "
+                        "you should consider setting standard_parallel "
+                        "for one value or standard_parallel1 and "
+                        "standard_parallel2 for two values",
+                        CMOR_WARNING,
+                        grid_attributes[i]);
+                }
+            } else {
+                cmor_handle_error_variadic(
+                    "Grid mapping attribute %s has not been set, "
+                    "you should consider setting it",
+                    CMOR_WARNING,
+                    grid_attributes[i]);
+            }
         }
     }
 

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -730,7 +730,9 @@ int cmor_set_grid_mapping(int gid, char *name, int nparam,
                                    &grid_attributes[0]) == 1) {
             if ((strcmp(lattributes_names[i], "standard_parallel1") == 0
                  || strcmp(lattributes_names[i], "standard_parallel2") == 0)
-                && (strcmp(name, "lambert_conformal_conic") == 0)) {
+                && (strcmp(name, "lambert_conformal_conic") == 0
+                    || strcmp(name, "albers_conical_equal_area") == 0)
+            ) {
 
 /* -------------------------------------------------------------------- */
 /*      ok do nothing it is just that we need 2 values for this         */

--- a/Test/test_cmor_crs.py
+++ b/Test/test_cmor_crs.py
@@ -266,7 +266,7 @@ class TestLatLonGridMapping(BaseCVsTest):
 
 class TestStandardParallel(BaseCVsTest):
 
-    def test_grid_mapping_without_standard_parallel(self, crs_wkt=None):
+    def test_grid_mapping_without_standard_parallel(self):
         cmor.setup(inpath='cmip6-cmor-tables/Tables',
                    netcdf_file_action=cmor.CMOR_REPLACE,
                    logfile=self.tmpfile)
@@ -308,11 +308,6 @@ class TestStandardParallel(BaseCVsTest):
                   "false_northing"]
         punits = ["", "", "", ""]
         pvalues = [175., 13., 8., 0.]
-
-        if crs_wkt is not None:
-            params.append("crs_wkt")
-            punits.append("")
-            pvalues.append(crs_wkt)
 
         cmor.set_crs(grid_id=grid_id,
                      mapping_name=mapnm,


### PR DESCRIPTION
Resolves #845 

A warning message won't be displayed by `cmor_set_grid_mapping` or `cmor_set_crs`  for a missing `standard_parallel` parameter if passing two values with `standard_parallel1` and `standard_parallel2`.

This PR also allows the `albers_conical_equal_area` grid mapping to have two standard parallel values.