### PR TITLE
Issue843 durack1 update cmip7 cv test file

### DIFF
--- a/TestTables/CMIP7_CV.json
+++ b/TestTables/CMIP7_CV.json
@@ -2,12 +2,35 @@
     "CV":{
         "DRS":{
             "directory_path_example":"CMIP7/CMIP/PCMDI-test-1-0/glb/mon/historical/r1i1p1f3/tas/tavg-h2m-hxy-u/gn/v20191207/",
-            "directory_path_template":"<mip_era><activity_id><source_id><region><frequency><experiment_id><variant_label><variable_id><branding_suffix><grid_label><version>",
-            "filename_example":"tas_tavg-h2m-hxy-u_mon_glb_gn_PCMDI-test-1-0_historical_r1i1p1f3_185001-186912.nc",
-            "filename_template":"<variable_id><branding_suffix><frequency><region><grid_label><source_id><experiment_id><variant_label>"
+            "directory_path_template":"<mip_era>/<activity_id>/<source_id>/<region>/<frequency>/<experiment_id>/<variant_id>/<variable_id>/<branding_suffix>/<grid_label>/<version>",
+            "filename_example":"tas_tavg-h2m-hxy-u_mon_glb_gn_PCMDI-test-1-0 _historical_r1i1p1f3_185001-186912.nc",
+            "filename_template":"<variable_id>_<branding_suffix>_<frequency>_<region>_<grid_label>_<source_id>_<experiment_id>_<variant_id>[_<time_range>].nc"
         },
-        "archive_id":{
-            "WCRP":"a collection of datasets from the AMIP and CMIP project phases, along with project supporting datasets from the input4MIPs (forcing datasets used to drive CMIP simulations) and obs4MIPs (observational datasets used to evaluate CMIP simulations, and numerous other supporting activities"
+        "activity_id":{
+            "AerChemMIP":"Aerosols and Chemistry Model Intercomparison Project",
+            "C4MIP":"Coupled Climate Carbon Cycle Model Intercomparison Project",
+            "CDRMIP":"Carbon Dioxide Removal Model Intercomparison Project",
+            "CFMIP":"Cloud Feedback Model Intercomparison Project",
+            "CMIP":"CMIP DECK: 1pctCO2, abrupt4xCO2, amip, esm-piControl, esm-historical, historical, and piControl experiments",
+            "CORDEX":"Coordinated Regional Climate Downscaling Experiment",
+            "DAMIP":"Detection and Attribution Model Intercomparison Project",
+            "DCPP":"Decadal Climate Prediction Project",
+            "DynVarMIP":"Dynamics and Variability Model Intercomparison Project",
+            "FAFMIP":"Flux-Anomaly-Forced Model Intercomparison Project",
+            "GMMIP":"Global Monsoons Model Intercomparison Project",
+            "GeoMIP":"Geoengineering Model Intercomparison Project",
+            "HighResMIP":"High-Resolution Model Intercomparison Project",
+            "ISMIP6":"Ice Sheet Model Intercomparison Project for CMIP6",
+            "LS3MIP":"Land Surface, Snow and Soil Moisture",
+            "LUMIP":"Land-Use Model Intercomparison Project",
+            "OMIP":"Ocean Model Intercomparison Project",
+            "PAMIP":"Polar Amplification Model Intercomparison Project",
+            "PMIP":"Palaeoclimate Modelling Intercomparison Project",
+            "RFMIP":"Radiative Forcing Model Intercomparison Project",
+            "SIMIP":"Sea Ice Model Intercomparison Project",
+            "ScenarioMIP":"Scenario Model Intercomparison Project",
+            "VIACSAB":"Vulnerability, Impacts, Adaptation and Climate Services Advisory Board",
+            "VolMIP":"Volcanic Forcings Model Intercomparison Project"
         },
         "area_label":{
             "air":"air",
@@ -36,7 +59,10 @@
             "veg":"vegetation",
             "wl":"wetland"
         },
-        "branding_suffix":"<temporal_label><vertical_label><horizontal_label><area_label>",
+        "branding_suffix":"<temporal_label>-<vertical_label>-<horizontal_label>-<area_label>",
+        "data_archive_id":{
+            "WCRP":"a collection of datasets from the AMIP and CMIP project phases, along with project supporting datasets from the input4MIPs (forcing datasets used to drive CMIP simulations) and obs4MIPs (observational datasets used to evaluate CMIP simulations), and numerous other supporting activities"
+        },
         "data_specs_version":"CMIP-7.0.0.0",
         "experiment_id":{
             "1pctCO2":{
@@ -52,7 +78,6 @@
                 "end_year":"",
                 "experiment":"1 percent per year increase in CO2",
                 "experiment_id":"1pctCO2",
-                "host_collection":"CMIP7",
                 "min_number_yrs_per_sim":"150",
                 "parent_activity_id":[
                     "CMIP"
@@ -64,6 +89,9 @@
                     "AOGCM"
                 ],
                 "start_year":"",
+                "sub_experiment_id":[
+                    "none"
+                ],
                 "tier":"1"
             }
         },
@@ -124,19 +152,9 @@
         "institution_id":{
             "PCMDI":"Program for Climate Model Diagnosis and Intercomparison, Lawrence Livermore National Laboratory, Livermore, CA 94550, USA"
         },
-        "license":{
-            "license_id":{
-                "CC BY 4.0":{
-                    "license_type":"Creative Commons Attribution 4.0 International",
-                    "license_url":"https://creativecommons.org/licenses/by/4.0/"
-                },
-                "CC0 1.0":{
-                    "license_type":"Creative Commons CC0 1.0 Universal Public Domain Dedication",
-                    "license_url":"https://creativecommons.org/publicdomain/zero/1.0/"
-                }
-            },
-            "license_template":"<license_id>; CMIP7 data produced by <institution_id> is licensed under a <license_type> License (<license_url>). Consult https://pcmdi.llnl.gov/CMIP7/TermsOfUse for terms of use governing CMIP7 output, including citation requirements and proper acknowledgment. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
-        },
+        "license":[
+            "^CMIP7 model data produced by .* is licensed under a Creative Commons .* License (https://creativecommons\\.org/.*)\\. *Consult https://pcmdi\\.llnl\\.gov/CMIP7/TermsOfUse for terms of use governing CMIP7 output, including citation requirements and proper acknowledgment\\. *Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file).*\\. *The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose\\. *All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law\\.$"
+        ],
         "mip_era":"CMIP7",
         "nominal_resolution":[
             "0.25 km",
@@ -268,7 +286,6 @@
                     }
                 },
                 "release_year":"1989",
-                "source":"PCMDI-test 1.0 (1989): \naerosol: none\natmos: Earth1.0-gettingHotter (360 x 180 longitude/latitude; 50 levels; top level 0.1 mb)\natmosChem: none\nland: Earth1.0\nlandIce: none\nocean: BlueMarble1.0-warming (360 x 180 longitude/latitude; 50 levels; top grid cell 0-10 m)\nocnBgchem: none\nseaIce: Declining1.0-warming (360 x 180 longitude/latitude)",
                 "source_id":"PCMDI-test-1-0"
             }
         },
@@ -295,9 +312,6 @@
         },
         "tracking_id":[
             "hdl:21.14100/.*"
-        ],
-        "variant_label":[
-            "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
         ],
         "vertical_label":{
             "1000hPa":"1000 hPa",

--- a/TestTables/CMIP7_atmos2d.json
+++ b/TestTables/CMIP7_atmos2d.json
@@ -1,7 +1,7 @@
 {
     "Header":{
         "Conventions":"CF-1.11 CMIP-7.0.0.0",
-        "checksum":"16d968eb7e89b5b95d1e119e32aaa0db",
+        "checksum":"864a8339b85c0027662cd659c2fd037b",
         "cmor_version":"3.10",
         "generic_levels":"alevel alevhalf",
         "int_missing_value":"-999",
@@ -11,7 +11,7 @@
         "positive":"",
         "product":"model-output",
         "realm":"atmos",
-        "table_date":"2025-03-12",
+        "table_date":"2025-07-24",
         "table_id":"atmos2d",
         "type":"real",
         "valid_max":"",

--- a/TestTables/CMIP7_ocean2d.json
+++ b/TestTables/CMIP7_ocean2d.json
@@ -1,7 +1,7 @@
 {
     "Header":{
         "Conventions":"CF-1.11 CMIP-7.0.0.0",
-        "checksum":"0d05fb60cb5645eb4b581f5c77508f7c",
+        "checksum":"ef793961ad6b3d0e7bb96eae8d648dec",
         "cmor_version":"3.10",
         "generic_levels":"",
         "int_missing_value":"-999",
@@ -11,7 +11,7 @@
         "positive":"",
         "product":"model-output",
         "realm":"ocean",
-        "table_date":"2025-03-12",
+        "table_date":"2025-07-24",
         "table_id":"ocean2d",
         "type":"real",
         "valid_max":"",

--- a/TestTables/CMIP7_oceanLev.json
+++ b/TestTables/CMIP7_oceanLev.json
@@ -1,7 +1,7 @@
 {
     "Header":{
         "Conventions":"CF-1.11 CMIP-7.0.0.0",
-        "checksum":"651bbe7b494203f2383f6feee44ad299",
+        "checksum":"089d5150b022a8df8b98009381b729c9",
         "cmor_version":"3.10",
         "generic_levels":"olevel olevhalf",
         "int_missing_value":"-999",
@@ -11,7 +11,7 @@
         "positive":"",
         "product":"model-output",
         "realm":"ocean",
-        "table_date":"2025-03-12",
+        "table_date":"2025-07-24",
         "table_id":"oceanLev",
         "type":"real",
         "valid_max":"",

--- a/TestTables/makeCMIP7MIPTables.ipynb
+++ b/TestTables/makeCMIP7MIPTables.ipynb
@@ -41,30 +41,31 @@
    "id": "f4932c47-b1da-4bad-b3e6-3864bc9d8214",
    "metadata": {},
    "source": [
-    "**Summary**\n",
+    "**Summary:**\n",
     "\n",
     "This file pulls a CMIP6Plus/CMOR3.9.0-era MIP table files, strips out extraneous variables and saves the files for local use\n",
     "\n",
-    "**Authors**\n",
+    "**Authors:**\n",
     "\n",
     "Paul J. Durack ([durack1](https://github.com/durack1); [PCMDI](https://pcmdi.llnl.gov/), [Lawrence Livermore National Laboratory](https://www.llnl.gov/))\n",
     "\n",
-    "**Notes**\n",
+    "**Notes:**\n",
     "\n",
     "PJD 25 Feb 2025 - initiated<br>\n",
     "PJD 25 Feb 2025 - first pass at initial CMOR 3.10 test tables and CMIP7_CV.json<br>\n",
     "KET 25 Feb 2025 - update to run local in TestTables<br>\n",
     "PJD  3 Mar 2025 - updated frequency with approx_interval<br>\n",
     "PJD  3 Mar 2025 - augmented with CMOR-required entries<BR>\n",
-    "PJD  5 Mar 2025 - updates following comments in https://github.com/PCMDI/cmor/pull/778/files/b9f28097dcf1afc99c7823dbdd0991e646de600f<br>\n",
+    "PJD  5 Mar 2025 - updates following comments in [PCMDI/cmor/pull#778](https://github.com/PCMDI/cmor/pull/778/files/b9f28097dcf1afc99c7823dbdd0991e646de600f)<br>\n",
     "PJD  9 Mar 2025 - adding nominal_resolution, data_archive_id, and regions<br>\n",
     "PJD  9 Mar 2025 - frequency tweaks (correct for pt entries)<br>\n",
     "PJD  9 Mar 2025 - add nominal_resolution = 0.25 km; update region identifiers; remove monC frequency<br>\n",
     "PJD 12 Mar 2025 - further updates to 1) add DRS; 2) remove nested branding_label dict; 3) remove nom*_res 1x1 degree<br>\n",
+    "PJD 24 Jul 2025 - updated to include missing `activity_id` entry<br>\n",
     "\n",
-    "TODO:\n",
+    "***TODO:***\n",
     "\n",
-    "**Links**"
+    "**Links:**"
    ]
   },
   {
@@ -85,8 +86,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 40.2 ms, sys: 17.4 ms, total: 57.6 ms\n",
-      "Wall time: 65.8 ms\n"
+      "CPU times: user 32.3 ms, sys: 11.3 ms, total: 43.5 ms\n",
+      "Wall time: 50.1 ms\n"
      ]
     }
    ],
@@ -155,8 +156,8 @@
       "APday\n",
       "OPmon\n",
       "OPmonLev\n",
-      "CPU times: user 36.7 ms, sys: 16.8 ms, total: 53.5 ms\n",
-      "Wall time: 15.8 s\n"
+      "CPU times: user 8.77 ms, sys: 4.43 ms, total: 13.2 ms\n",
+      "Wall time: 54.5 ms\n"
      ]
     }
    ],
@@ -373,13 +374,13 @@
      "data": {
       "text/plain": [
        "{'Header': {'Conventions': 'CF-1.11 CMIP-7.0.0.0',\n",
-       "  'checksum': '16d968eb7e89b5b95d1e119e32aaa0db',\n",
+       "  'checksum': '864a8339b85c0027662cd659c2fd037b',\n",
        "  'cmor_version': '3.10',\n",
        "  'generic_levels': 'alevel alevhalf',\n",
        "  'int_missing_value': '-999',\n",
        "  'missing_value': '1e20',\n",
        "  'product': 'model-output',\n",
-       "  'table_date': '2025-03-12',\n",
+       "  'table_date': '2025-07-24',\n",
        "  'table_id': 'atmos2d',\n",
        "  'realm': 'atmos',\n",
        "  'type': 'real',\n",
@@ -486,13 +487,13 @@
      "data": {
       "text/plain": [
        "{'Header': {'Conventions': 'CF-1.11 CMIP-7.0.0.0',\n",
-       "  'checksum': '0d05fb60cb5645eb4b581f5c77508f7c',\n",
+       "  'checksum': 'ef793961ad6b3d0e7bb96eae8d648dec',\n",
        "  'cmor_version': '3.10',\n",
        "  'generic_levels': '',\n",
        "  'int_missing_value': '-999',\n",
        "  'missing_value': '1e20',\n",
        "  'product': 'model-output',\n",
-       "  'table_date': '2025-03-12',\n",
+       "  'table_date': '2025-07-24',\n",
        "  'table_id': 'ocean2d',\n",
        "  'realm': 'ocean',\n",
        "  'type': 'real',\n",
@@ -566,13 +567,13 @@
      "data": {
       "text/plain": [
        "{'Header': {'Conventions': 'CF-1.11 CMIP-7.0.0.0',\n",
-       "  'checksum': '651bbe7b494203f2383f6feee44ad299',\n",
+       "  'checksum': '089d5150b022a8df8b98009381b729c9',\n",
        "  'cmor_version': '3.10',\n",
        "  'generic_levels': 'olevel olevhalf',\n",
        "  'int_missing_value': '-999',\n",
        "  'missing_value': '1e20',\n",
        "  'product': 'model-output',\n",
-       "  'table_date': '2025-03-12',\n",
+       "  'table_date': '2025-07-24',\n",
        "  'table_id': 'oceanLev',\n",
        "  'realm': 'ocean',\n",
        "  'type': 'real',\n",
@@ -656,8 +657,8 @@
      "output_type": "stream",
      "text": [
       "CV\n",
-      "CPU times: user 16.5 ms, sys: 6.39 ms, total: 22.9 ms\n",
-      "Wall time: 5.26 s\n"
+      "CPU times: user 4.68 ms, sys: 1.88 ms, total: 6.56 ms\n",
+      "Wall time: 18 ms\n"
      ]
     }
    ],
@@ -690,6 +691,7 @@
     "keyList = list(CV[\"CV\"].keys())\n",
     "keepKeys = [\n",
     "    \"DRS\",\n",
+    "    \"activity_id\",\n",
     "    \"frequency\",\n",
     "    \"grid_label\",\n",
     "    \"license\",\n",
@@ -878,7 +880,7 @@
     "        \"a collection of datasets from the AMIP and CMIP project phases,\",\n",
     "        \"along with project supporting datasets from the input4MIPs\",\n",
     "        \"(forcing datasets used to drive CMIP simulations) and obs4MIPs\",\n",
-    "        \"(observational datasets used to evaluate CMIP simulations, and\",\n",
+    "        \"(observational datasets used to evaluate CMIP simulations), and\",\n",
     "        \"numerous other supporting activities\",\n",
     "    ]\n",
     ")\n",
@@ -1266,6 +1268,14 @@
     "            dic, f, ensure_ascii=True, sort_keys=True, indent=4, separators=(\",\", \":\")\n",
     "        )"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c86147-e793-4d4f-9f9e-2fcb2952630b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1284,7 +1294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix #843 

@taylor13 if you have a chance, it would be great to get some eyeballs on this update. The missing `activity_id` (circa CMIP6) is added back in, but I also see that `archive_id` has been renamed `data_archive_id`, which I wasn't expecting - would be good to triple check against the latest CV TT thinking to make sure we're not missing other updates.

Some things that I've noted are other changes to `license` (which I will need to revert), `experiment_id:host_collection`, `source_id:source`, `variant_label`, and `branding_suffix`, some of which look ok, but others need a review