### PR TITLE
Remove Python 3.9 build from nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ workflows:
               matrix:
                  parameters:
                     os: [ linux ]
-                    python_version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+                    python_version: [ "3.10", "3.11", "3.12", "3.13" ]
               name: build-<< matrix.os >>-<< matrix.python_version >>
 
          - upload:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,7 +28,7 @@ jobs:
             C_COMPILER: clang_osx-64 
             FORTRAN_COMPILER: gfortran_osx-64
             PROJECT_DIR: workdir/macos_64
-        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.runner.RUNNER_OS }}
     env:
       PACKAGE_NAME: cmor


### PR DESCRIPTION
Due to [conda-forge dropping support for Python 3.9](https://conda-forge.org/news/2025/08/18/python-3-9/), we are removing Python 3.9 nightly builds.