### PR TITLE
Warn users when the time values they pass don't match those created from the bounds they pass

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -241,6 +241,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_nested_cv_attribute.py make test_a_python
 	env TEST_NAME=Test/test_cmor_path_and_file_templates.py make test_a_python
 	env TEST_NAME=Test/test_cmor_check_cv_structure.py make test_a_python
+	env TEST_NAME=Test/test_cmor_time_value_and_bounds_mismatch.py make test_a_python
 test_cmip6_cv: python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentnotset.py make test_a_python
 	env TEST_NAME=Test/test_python_CMIP6_CV_sub_experimentbad.py make test_a_python

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -2126,7 +2126,7 @@ int cmor_axis(int *axis_id, char *name, char *units, int length,
                        + cmor_axes[cmor_naxes].bounds[2 * i + 1]) / 2.;
                     diff = fabs(cmor_axes[cmor_naxes].values[i]
                                 - value_from_bounds);
-                    if (time_bound_mismatch_found == 0 && diff > 0.5) {
+                    if (time_bound_mismatch_found == 0 && diff > 1e-6) {
                         time_bound_mismatch_found = 1;
                         cmor_handle_error_variadic(
                             "The values you provided for axis %s are "

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -1347,6 +1347,7 @@ void cmor_values_from_bounds(double *bounds, double *values_from_user,
     int bound_mismatch_found = 0;
     int i;
 
+    cmor_add_traceback("cmor_values_from_bounds");
     for (i = 0; i < length; i++) {
         value_user = values_from_user[i];
         value_bounds = (bounds[2 * i] + bounds[2 * i + 1]) / 2.;
@@ -1371,6 +1372,8 @@ void cmor_values_from_bounds(double *bounds, double *values_from_user,
         }
         values_from_bounds[i] = value_bounds;
     }
+    cmor_pop_traceback();
+    return;
 }
 
 /************************************************************************/

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -1676,8 +1676,7 @@ int cmor_axis(int *axis_id, char *name, char *units, int length,
     extern int CMOR_TABLE;
 
     double approx_interval, interval_error, interval_warning;
-    double value_from_bounds, diff;
-    int i, iref, j, k, l, cv_freq_found, time_bound_mismatch_found;
+    int i, iref, j, k, l, cv_freq_found;
     cmor_axis_def_t refaxis;
     cmor_CV_def_t *frequencies_cv, *freq_cv, *interv_cv,
     *interv_error_cv, *interv_warning_cv;

--- a/Src/cmor_axes.c
+++ b/Src/cmor_axes.c
@@ -1337,6 +1337,43 @@ int cmor_treat_axis_values(int axis_id, double *values, int length,
 }
 
 /************************************************************************/
+/*                      cmor_values_from_bounds()                       */
+/************************************************************************/
+void cmor_values_from_bounds(double *bounds, double *values_from_user,
+                             double *values_from_bounds, int length,
+                             char *name)
+{
+    double diff, value_user, value_bounds;
+    int bound_mismatch_found = 0;
+    int i;
+
+    for (i = 0; i < length; i++) {
+        value_user = values_from_user[i];
+        value_bounds = (bounds[2 * i] + bounds[2 * i + 1]) / 2.;
+        diff = fabs(value_user - value_bounds);
+        if (bound_mismatch_found == 0 && diff > 1e-6) {
+            bound_mismatch_found = 1;
+            cmor_handle_error_variadic(
+                "The values you provided for axis %s are "
+                "different from those computed from the "
+                "bounds, which are used for the axis values "
+                "instead of the user-provided values."
+                "\n!\n! "
+                "The first value found is at index %i: %lf "
+                "will be replaced with %lf between bounds "
+                "%lf and %lf",
+                CMOR_WARNING,
+                name, i,
+                value_user,
+                value_bounds,
+                bounds[2 * i],
+                bounds[2 * i + 1]);
+        }
+        values_from_bounds[i] = value_bounds;
+    }
+}
+
+/************************************************************************/
 /*                        cmor_check_interval()                         */
 /************************************************************************/
 int cmor_check_interval(int axis_id, char *interval, double *values,
@@ -2119,33 +2156,12 @@ int cmor_axis(int *axis_id, char *name, char *units, int length,
 /* -------------------------------------------------------------------- */
 /*      ok now we need to overwrite the time values with mid point      */
 /* -------------------------------------------------------------------- */
-                time_bound_mismatch_found = 0;
-                for (i = 0; i < length; i++) {
-                    value_from_bounds =
-                      (cmor_axes[cmor_naxes].bounds[2 * i]
-                       + cmor_axes[cmor_naxes].bounds[2 * i + 1]) / 2.;
-                    diff = fabs(cmor_axes[cmor_naxes].values[i]
-                                - value_from_bounds);
-                    if (time_bound_mismatch_found == 0 && diff > 1e-6) {
-                        time_bound_mismatch_found = 1;
-                        cmor_handle_error_variadic(
-                            "The values you provided for axis %s are "
-                            "different from those computed from the "
-                            "bounds, which are used for the axis values "
-                            "instead of the user-provided values."
-                            "\n!\n! "
-                            "The first value found is at index %i: %lf "
-                            "will be replaced with %lf between bounds "
-                            "%lf and %lf",
-                            CMOR_WARNING,
-                            name, i,
-                            cmor_axes[cmor_naxes].values[i],
-                            value_from_bounds,
-                            cmor_axes[cmor_naxes].bounds[2 * i],
-                            cmor_axes[cmor_naxes].bounds[2 * i + 1]);
-                    }
-                    cmor_axes[cmor_naxes].values[i] = value_from_bounds;
-                }
+                cmor_values_from_bounds(cmor_axes[cmor_naxes].bounds,
+                                        cmor_axes[cmor_naxes].values,
+                                        cmor_axes[cmor_naxes].values,
+                                        length,
+                                        name
+                                        );
 /* -------------------------------------------------------------------- */
 /*      here we check if interval is about right                        */
 /*      just keep the begining of units out                             */

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -3272,8 +3272,8 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                     for (i = 0; i < ntimes_passed; i++) {
                         value_from_bounds =
                           (tmp_vals[2 * i] + tmp_vals[2 * i + 1]) / 2.;
-                        diff = fabs(tmp_vals[i] - value_from_bounds);
-                        if (time_bound_mismatch_found == 0 && diff > 0.5) {
+                        diff = fabs(time_vals[i] - value_from_bounds);
+                        if (time_bound_mismatch_found == 0 && diff > 1e-6) {
                             time_bound_mismatch_found = 1;
                             cmor_handle_error_variadic(
                                 "The values you provided for axis %s are "
@@ -3286,7 +3286,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                                 "%lf and %lf",
                                 CMOR_WARNING,
                                 cmor_axes[avar->axes_ids[0]].id, i,
-                                tmp_vals[i],
+                                time_vals[i],
                                 value_from_bounds,
                                 tmp_vals[2 * i],
                                 tmp_vals[2 * i + 1]);

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2546,8 +2546,6 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
     cmor_axis_def_t *refaxis;
     size_t time_axis_start, time_axis_count;
     double *time_axis_vals;
-    int time_bound_mismatch_found;
-    double value_from_bounds, diff;
 
     cmor_add_traceback("cmor_write_var_to_file");
     cmor_is_setup();

--- a/Src/cmor_variables.c
+++ b/Src/cmor_variables.c
@@ -2529,7 +2529,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
     char msg[CMOR_MAX_STRING];
     char msg2[CMOR_MAX_STRING];
     char units[CMOR_MAX_STRING];
-    double *tmp_vals;
+    double *tmp_bnds, *tmp_time;
     ut_unit *user_units = NULL, *cmor_units = NULL;
     cv_converter *ut_cmor_converter = NULL;
     char local_unit[CMOR_MAX_STRING];
@@ -3176,8 +3176,10 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                 cmor_get_axis_attribute(avar->axes_ids[0], "units", 'c', &msg);
                 cmor_get_cur_dataset_attribute("calendar", msg2);
 
-                tmp_vals = malloc((ntimes_passed + 1) * 2 * sizeof(double));
-                if (tmp_vals == NULL) {
+                tmp_bnds = malloc((ntimes_passed + 1) * 2 * sizeof(double));
+                tmp_time = (double *)malloc(ntimes_passed * sizeof(double));
+
+                if (tmp_bnds == NULL) {
                     cmor_handle_error_variadic(
                         "cannot malloc %i tmp bounds time vals "
                         "for variable '%s' (table: %s)",
@@ -3189,7 +3191,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                     if ((avar->last_time != -999.)
                         && (avar->last_bound != 1.e20)) {
                         tmpindex = 1;
-                        tmp_vals[0] = avar->last_time;
+                        tmp_bnds[0] = avar->last_time;
                     } else {
                         tmpindex = 0;
                     }
@@ -3197,12 +3199,12 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                     tmpindex = 0;
                 }
                 ierr = cmor_convert_time_values(time_vals, 'd', ntimes_passed,
-                                                &tmp_vals[tmpindex],
+                                                &tmp_bnds[tmpindex],
                                                 cmor_axes[avar->
                                                           axes_ids[0]].iunits,
                                                 msg, msg2, msg2);
 
-                ierr = cmor_check_monotonic(&tmp_vals[0],
+                ierr = cmor_check_monotonic(&tmp_bnds[0],
                                             ntimes_passed + tmpindex, "time", 0,
                                             avar->axes_ids[0]);
 
@@ -3211,19 +3213,19 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                     if ((avar->last_time != -999.)
                         && (avar->last_bound != 1.e20)) {
 
-                        tmp_vals[0] = 2 * avar->last_time - avar->last_bound;
-                        tmp_vals[1] = avar->last_bound;
+                        tmp_bnds[0] = 2 * avar->last_time - avar->last_bound;
+                        tmp_bnds[1] = avar->last_bound;
                     }
                 }
 
                 ierr = cmor_convert_time_values(time_bounds, 'd',
                                                 ntimes_passed * 2,
-                                                &tmp_vals[2 * tmpindex],
+                                                &tmp_bnds[2 * tmpindex],
                                                 cmor_axes[avar->
                                                           axes_ids[0]].iunits,
                                                 msg, msg2, msg2);
 
-                        ierr = cmor_check_monotonic(&tmp_vals[0],
+                        ierr = cmor_check_monotonic(&tmp_bnds[0],
                             (ntimes_passed + tmpindex) * 2,
                             "time", 1, avar->axes_ids[0]);
 
@@ -3232,7 +3234,7 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                                                        ntimes_passed, "time");
 
                 ierr = nc_put_vara_double(ncid, avar->time_bnds_nc_id, starts,
-                                          counts2, &tmp_vals[2 * tmpindex]);
+                                          counts2, &tmp_bnds[2 * tmpindex]);
 
                 if (ierr != NC_NOERR) {
                     cmor_handle_error_variadic(
@@ -3249,70 +3251,51 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
 /*      Ok first time we're putting data  in                            */
 /* -------------------------------------------------------------------- */
 
-                    avar->first_bound = tmp_vals[0];
+                    avar->first_bound = tmp_bnds[0];
                 } else {
 /* -------------------------------------------------------------------- */
 /*      ok let's put the bounds back on "normal" (start at 0) indices   */
 /* -------------------------------------------------------------------- */
 
                     for (i = 0; i < 2 * ntimes_passed; i++) {
-                        tmp_vals[i] = tmp_vals[i + 2];
+                        tmp_bnds[i] = tmp_bnds[i + 2];
                     }
                 }
-                avar->last_bound = tmp_vals[ntimes_passed * 2 - 1];
+                avar->last_bound = tmp_bnds[ntimes_passed * 2 - 1];
 
 /* -------------------------------------------------------------------- */
 /*      ok since we have bounds we need to set time in the middle       */
 /*      but only do this in case of none climato                        */
 /* -------------------------------------------------------------------- */
                 if (cmor_tables[cmor_axes[avar->axes_ids[0]].ref_table_id].axes
-                    [cmor_axes[avar->axes_ids[0]].ref_axis_id].climatology ==
-                    0) {
-                    time_bound_mismatch_found = 0;
-                    for (i = 0; i < ntimes_passed; i++) {
-                        value_from_bounds =
-                          (tmp_vals[2 * i] + tmp_vals[2 * i + 1]) / 2.;
-                        diff = fabs(time_vals[i] - value_from_bounds);
-                        if (time_bound_mismatch_found == 0 && diff > 1e-6) {
-                            time_bound_mismatch_found = 1;
-                            cmor_handle_error_variadic(
-                                "The values you provided for axis %s are "
-                                "different from those computed from the "
-                                "bounds, which are used for the axis values "
-                                "instead of the user-provided values."
-                                "\n!\n! "
-                                "The first value found is at index %zu: %lf "
-                                "will be replaced with %lf between bounds "
-                                "%lf and %lf",
-                                CMOR_WARNING,
-                                cmor_axes[avar->axes_ids[0]].id, i,
-                                time_vals[i],
-                                value_from_bounds,
-                                tmp_vals[2 * i],
-                                tmp_vals[2 * i + 1]);
-                        }
-                        tmp_vals[i] = value_from_bounds;
-                    }
+                    [cmor_axes[avar->axes_ids[0]].ref_axis_id].climatology == 0) 
+                {
+                    cmor_values_from_bounds(tmp_bnds,
+                                            time_vals,
+                                            tmp_time,
+                                            ntimes_passed,
+                                            cmor_axes[avar->axes_ids[0]].id
+                                            );
 /* -------------------------------------------------------------------- */
 /*      store for later                                                 */
 /* -------------------------------------------------------------------- */
 
-                    first_time = tmp_vals[0];
+                    first_time = tmp_time[0];
                 } else {
 /* -------------------------------------------------------------------- */
-/*      we need to put into tmp_vals the right things                   */
+/*      we need to put into tmp_time the right things                   */
 /* -------------------------------------------------------------------- */
                     ierr = cmor_convert_time_values(time_vals, 'd',
-                                                    ntimes_passed, &tmp_vals[0],
+                                                    ntimes_passed, &tmp_time[0],
                                                     cmor_axes[avar->axes_ids
                                                               [0]].iunits, msg,
                                                     msg2, msg2);
 
-                    first_time = tmp_vals[0];   /*store for later */
+                    first_time = tmp_time[0];   /*store for later */
                 }
 
                 ierr = nc_put_vara_double(ncid, avar->time_nc_id, starts,
-                                          counts, &tmp_vals[0]);
+                                          counts, &tmp_time[0]);
                 if (ierr != NC_NOERR) {
                     cmor_handle_error_variadic(
                         "NetCDF error (%i: %s) writing time values for variable '%s' (%s)",
@@ -3335,21 +3318,22 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
 
                 } else {
 
-                    if (tmp_vals[0] < avar->last_time) {
+                    if (tmp_time[0] < avar->last_time) {
                         cmor_handle_error_variadic(
                             "Time point: %lf ( %lf in output units) "
                             "is not monotonic last time was: %lf "
                             "(in output units), variable %s (table: %s)",
                             CMOR_CRITICAL,
-                            time_vals[0], tmp_vals[0], avar->last_time,
+                            time_vals[0], tmp_time[0], avar->last_time,
                             avar->id,
                             cmor_tables[avar->ref_table_id].szTable_id);
                     }
                 }
 
-                avar->last_time = tmp_vals[ntimes_passed - 1];
+                avar->last_time = tmp_time[ntimes_passed - 1];
 
-                free(tmp_vals);
+                free(tmp_bnds);
+                free(tmp_time);
             } else {
 /* -------------------------------------------------------------------- */
 /*      checks if you need bounds or not                                */
@@ -3373,9 +3357,9 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                 cmor_get_axis_attribute(avar->axes_ids[0], "units", 'c', &msg);
                 cmor_get_cur_dataset_attribute("calendar", msg2);
 
-                tmp_vals = malloc(ntimes_passed * sizeof(double));
+                tmp_time = malloc(ntimes_passed * sizeof(double));
 
-                if (tmp_vals == NULL) {
+                if (tmp_time == NULL) {
                     cmor_handle_error_variadic(
                         "cannot malloc %i time vals for variable "
                         "'%s' (table: %s)",
@@ -3384,24 +3368,24 @@ int cmor_write_var_to_file(int ncid, cmor_var_t * avar, void *data,
                         cmor_tables[avar->ref_table_id].szTable_id);
                 }
                 ierr = cmor_convert_time_values(time_vals, 'd', ntimes_passed,
-                                                &tmp_vals[0],
+                                                &tmp_time[0],
                                                 cmor_axes[avar->
                                                           axes_ids[0]].iunits,
                                                 msg, msg2, msg2);
 
                 ierr = nc_put_vara_double(ncid, avar->time_nc_id, starts,
-                                          counts, tmp_vals);
+                                          counts, tmp_time);
 
                 if (avar->ntimes_written == 0) {
 /* -------------------------------------------------------------------- */
 /*       ok first time we're putting data  in                           */
 /* -------------------------------------------------------------------- */
 
-                    avar->first_time = tmp_vals[0];
+                    avar->first_time = tmp_time[0];
                 }
-                avar->last_time = tmp_vals[ntimes_passed - 1];
+                avar->last_time = tmp_time[ntimes_passed - 1];
 
-                free(tmp_vals);
+                free(tmp_time);
                 if (ierr != NC_NOERR) {
                     cmor_handle_error_variadic(
                         "NetCDF error (%i: %s) writing times for variable '%s' "

--- a/Test/test_cmor_time_value_and_bounds_mismatch.py
+++ b/Test/test_cmor_time_value_and_bounds_mismatch.py
@@ -1,0 +1,372 @@
+import json
+import cmor
+import unittest
+import os
+import numpy
+import base_CMIP6_CV
+
+CV_PATH = "TestTables/CMIP7_CV.json"
+
+USER_INPUT = {
+    "_AXIS_ENTRY_FILE": "Tables/CMIP6_coordinate.json",
+    "_FORMULA_VAR_FILE": "Tables/CMIP6_formula_terms.json",
+    "_cmip7_option": 1,
+    "_controlled_vocabulary_file": CV_PATH,
+    "activity_id": "CMIP",
+    "branch_method": "standard",
+    "branch_time_in_child": 30.0,
+    "branch_time_in_parent": 10800.0,
+    "calendar": "360_day",
+    "cv_version": "6.2.19.0",
+    "experiment": "1 percent per year increase in CO2",
+    "experiment_id": "1pctCO2",
+    "forcing_index": "3",
+    "grid": "N96",
+    "grid_label": "gn",
+    "initialization_index": "1",
+    "institution_id": "PCMDI",
+    "license_id": "CC BY 4.0",
+    "nominal_resolution": "250 km",
+    "outpath": ".",
+    "parent_mip_era": "CMIP7",
+    "parent_time_units": "days since 1850-01-01",
+    "parent_activity_id": "CMIP",
+    "parent_source_id": "PCMDI-test-1-0",
+    "parent_experiment_id": "piControl",
+    "parent_variant_label": "r1i1p1f3",
+    "physics_index": "1",
+    "realization_index": "9",
+    "source_id": "PCMDI-test-1-0",
+    "source_type": "AOGCM CHEM BGC",
+    "tracking_prefix": "hdl:21.14100",
+    "host_collection": "CMIP7",
+    "frequency": "xxxxxxxxxxxx",
+    "region": "glb",
+    "archive_id": "WCRP"
+}
+
+
+class TestTimeBoundsMismatchMakingMonthlyAxis(base_CMIP6_CV.BaseCVsTest):
+
+    def setUp(self):
+        super().setUp()
+
+        frequency = "mon"
+        self.input_path = f"Test/input_making_{frequency}_axis.json"
+
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile=self.tmpfile)
+
+        with open(self.input_path, "w") as input_file:
+            user_input = USER_INPUT.copy()
+            user_input["frequency"] = frequency
+            json.dump(user_input, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json(self.input_path)
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+        
+        cmor.load_table("CMIP7_ocean2d.json")
+
+    def tearDown(self):
+        os.remove(self.input_path)
+        return super().tearDown()
+        
+    def assertWarningMessage(self, flag):
+        warn_msg = (
+            "Warning: The values you provided for axis time are different "
+            "from those computed from the bounds, which are used for the axis "
+            "values instead of the user-provided values."
+        )
+
+        with open(self.tmpfile, 'r') as f:
+            lines = f.readlines()
+            warning_found = any(warn_msg in l for l in lines)
+            self.assertEqual(flag, warning_found)
+
+    def test_make_axis_monthly_with_day_units_no_warning(self):
+        
+        time = numpy.array([15.5, 45.5])
+        time_bnds = numpy.array([0, 31, 60])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(False)
+
+    def test_make_axis_monthly_with_day_units_with_warning(self):
+        
+        time = numpy.array([15.5, 45])
+        time_bnds = numpy.array([0, 31, 60])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("45.000000 will be replaced with 45.500000 "
+                      "between bounds 31.000000 and 60.000000", 
+                      "! The first value found is at index 1: ")
+        
+
+    def test_make_axis_monthly_with_month_units(self):
+        
+        time = numpy.array([0, 1])
+        time_bnds = numpy.array([0, 1, 2])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="months since 2018")
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("0.000000 will be replaced with 15.000000 "
+                      "between bounds 0.000000 and 30.000000", 
+                      "! The first value found is at index 0: ")
+
+
+class TestTimeBoundsMismatchMaking6HourlyAxis(base_CMIP6_CV.BaseCVsTest):
+
+    def setUp(self):
+        super().setUp()
+
+        frequency = "6hr"
+        self.input_path = f"Test/input_making_{frequency}_axis.json"
+
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile=self.tmpfile)
+
+        with open(self.input_path, "w") as input_file:
+            user_input = USER_INPUT.copy()
+            user_input["frequency"] = frequency
+            json.dump(user_input, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json(self.input_path)
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+        
+        cmor.load_table("CMIP7_ocean2d.json")
+
+    def tearDown(self):
+        os.remove(self.input_path)
+        return super().tearDown()
+        
+    def assertWarningMessage(self, flag):
+        warn_msg = (
+            "Warning: The values you provided for axis time are different "
+            "from those computed from the bounds, which are used for the axis "
+            "values instead of the user-provided values."
+        )
+
+        with open(self.tmpfile, 'r') as f:
+            lines = f.readlines()
+            warning_found = any(warn_msg in l for l in lines)
+            self.assertEqual(flag, warning_found)
+
+    def test_make_axis_6hourly_with_day_units_no_warning(self):
+        
+        time = numpy.array([0.125, 0.375])
+        time_bnds = numpy.array([0, 0.25, 0.5])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(False)
+
+    def test_make_axis_6hourly_with_day_units_with_warning(self):
+        
+        time = numpy.array([0, 0.25])
+        time_bnds = numpy.array([0, 0.25, 0.5])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("0.000000 will be replaced with 0.125000 "
+                      "between bounds 0.000000 and 0.250000", 
+                      "! The first value found is at index 0: ")
+
+
+class TestTimeBoundsMismatchMakingYearlyAxis(base_CMIP6_CV.BaseCVsTest):
+
+    def setUp(self):
+        super().setUp()
+
+        frequency = "yr"
+        self.input_path = f"Test/input_making_{frequency}_axis.json"
+
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile=self.tmpfile)
+
+        with open(self.input_path, "w") as input_file:
+            user_input = USER_INPUT.copy()
+            user_input["frequency"] = frequency
+            json.dump(user_input, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json(self.input_path)
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+        
+        cmor.load_table("CMIP7_ocean2d.json")
+
+    def tearDown(self):
+        os.remove(self.input_path)
+        return super().tearDown()
+        
+    def assertWarningMessage(self, flag):
+        warn_msg = (
+            "Warning: The values you provided for axis time are different "
+            "from those computed from the bounds, which are used for the axis "
+            "values instead of the user-provided values."
+        )
+
+        with open(self.tmpfile, 'r') as f:
+            lines = f.readlines()
+            warning_found = any(warn_msg in l for l in lines)
+            self.assertEqual(flag, warning_found)
+
+    def test_make_axis_yearly_with_day_units_no_warning(self):
+        
+        time = numpy.array([182.5])
+        time_bnds = numpy.array([0, 365])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(False)
+
+    def test_make_axis_yearly_with_day_units_with_warning(self):
+        
+        time = numpy.array([0])
+        time_bnds = numpy.array([0, 365])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="days since 2018")
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("0.000000 will be replaced with 182.500000 "
+                      "between bounds 0.000000 and 365.000000", 
+                      "! The first value found is at index 0: ")
+
+    def test_make_axis_yearly_with_year_units_no_warning(self):
+        
+        time = numpy.array([0.5])
+        time_bnds = numpy.array([0, 1])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="years since 2018")
+
+        self.assertWarningMessage(False)
+
+    def test_make_axis_yearly_with_year_units_with_warning(self):
+        
+        time = numpy.array([0.5, 1])
+        time_bnds = numpy.array([0, 1, 2])
+
+        _ = cmor.axis("time",
+                      coord_vals=time,
+                      cell_bounds=time_bnds,
+                      units="years since 2018")
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("360.000000 will be replaced with 540.000000 "
+                      "between bounds 360.000000 and 720.000000", 
+                      "! The first value found is at index 1: ")
+
+
+class TestTimeBoundsMismatchTimesPassed(base_CMIP6_CV.BaseCVsTest):
+        
+    def assertWarningMessage(self, flag):
+        warn_msg = (
+            "Warning: The values you provided for axis time are different "
+            "from those computed from the bounds, which are used for the axis "
+            "values instead of the user-provided values."
+        )
+
+        with open(self.tmpfile, 'r') as f:
+            lines = f.readlines()
+            warning_found = any(warn_msg in l for l in lines)
+            self.assertEqual(flag, warning_found)
+
+    def test_time_value_bounds_mismatch_times_passed(self):
+
+        test_name = "time_value_bounds_mismatch_times_passed"
+        input_path = f"Test/input_{test_name}.json"
+        frequency = "mon"
+
+        cmor.setup(inpath="TestTables",
+                   netcdf_file_action=cmor.CMOR_REPLACE,
+                   logfile=self.tmpfile)
+
+        with open(input_path, "w") as input_file:
+            user_input = USER_INPUT.copy()
+            user_input["frequency"] = frequency
+            json.dump(user_input, input_file, sort_keys=True, indent=4)
+
+        # read dataset info
+        error_flag = cmor.dataset_json(input_path)
+        if error_flag:
+            raise RuntimeError("CMOR dataset_json call failed")
+
+        lat = numpy.array([10, 20, 30])
+        lat_bnds = numpy.array([5, 15, 25, 35])
+        lon = numpy.array([0, 90, 180, 270])
+        lon_bnds = numpy.array([-45, 45, 135, 225, 315])
+        time = numpy.array([15.5, 45])
+        time_bnds = numpy.array([0, 31, 60])
+        tos_shape = (time.shape[0], lat.shape[0], lon.shape[0])
+        tos = numpy.full(tos_shape, 27)
+        cmor.load_table("CMIP7_ocean2d.json")
+        cmorlat = cmor.axis("latitude",
+                            coord_vals=lat,
+                            cell_bounds=lat_bnds,
+                            units="degrees_north")
+        cmorlon = cmor.axis("longitude",
+                            coord_vals=lon,
+                            cell_bounds=lon_bnds,
+                            units="degrees_east")
+        cmortime = cmor.axis("time",
+                             units="days since 2018")
+        axes = [cmortime, cmorlat, cmorlon]
+        cmortos = cmor.variable("tos_tavg-u-hxy-sea", "degC", axes)
+
+        self.assertWarningMessage(False)
+
+        self.assertEqual(cmor.write(cmortos, tos, ntimes_passed=2,
+                                    time_vals=time, time_bnds=time_bnds), 0)
+
+        self.assertWarningMessage(True)
+        
+        self.assertCV("45.000000 will be replaced with 45.500000 "
+                      "between bounds 31.000000 and 60.000000", 
+                      "! The first value found is at index 1: ")
+
+        os.remove(input_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Test/test_python_CMIP6_CV_forcenoparent.py
+++ b/Test/test_python_CMIP6_CV_forcenoparent.py
@@ -58,7 +58,7 @@ class TestCase(base_CMIP6_CV.BaseCVsTest):
         for line in lines:
             if line.find('replaced') != -1:
                 count = count + 1
-        self.assertEqual(count, 6)
+        self.assertEqual(count, 7)
         f.close()
 
 

--- a/include/cmor_func_def.h
+++ b/include/cmor_func_def.h
@@ -190,6 +190,10 @@ extern int cmor_treat_axis_values( int axis_id, double *values, int length,
 extern int cmor_check_interval( int axis_id, char *interval,
 				double *values, int nvalues,
 				int isbounds );
+extern void cmor_values_from_bounds(double *bounds, 
+				double *values_from_user,
+				double *values_from_bounds, int length,
+				char *name);
 extern int cmor_axis( int *axis_id, char *name, char *units, int length,
 		      void *coord_vals, char type, void *cell_bounds,
 		      int cell_bounds_ndim, char *interval );


### PR DESCRIPTION
Resolves #852 

If the user passes time values that are not approximately (within 10<sup>-6</sup> days of) the midpoints computed from the time bounds passed, then the following warning message will be printed.

```
C Traceback:
In function: cmor_values_from_bounds
! called from: cmor_axis
! 

!!!!!!!!!!!!!!!!!!!!!!!!!
!
! Warning: The values you provided for axis time are different from those computed from the bounds, which are used for the axis values instead of the user-provided values.
!
! The first value found is at index 0: 0.000000 will be replaced with 15.000000 between bounds 0.000000 and 30.000000
!
!!!!!!!!!!!!!!!!!!!!!!!!!
```
