### PR TITLE
Explicitly install CMOR from the local channel in the nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ aliases:
        mamba activate
        export CMOR_CHANNEL=$HOME/cmor_conda_pkgs/
        set +e
-       mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS python=$PYTHON_VERSION $PKG_NAME=$VERSION $CONDA_COMPILERS
+       mamba create -y -n test_py$PYTHON_VERSION -c file://$CMOR_CHANNEL $CHANNELS file://$CMOR_CHANNEL::$PKG_NAME=$VERSION python=$PYTHON_VERSION $CONDA_COMPILERS
        mamba activate test_py$PYTHON_VERSION
        set -e
        ./configure --prefix=$CONDA_PREFIX --with-python --with-uuid=$CONDA_PREFIX --with-json-c=$CONDA_PREFIX --with-udunits2=$CONDA_PREFIX --with-netcdf=$CONDA_PREFIX  --enable-verbose-test

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -124,7 +124,7 @@ jobs:
 
           export CMOR_CHANNEL=file://$HOME/cmor_conda_pkgs/
 
-          mamba create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL python=$PYTHON_VERSION $PACKAGE_NAME=$PACKAGE_VERSION $C_COMPILER $FORTRAN_COMPILER
+          mamba create -y -n test_py$PYTHON_VERSION -c $CMOR_CHANNEL -c $CONDA_FORGE_CHANNEL $CMOR_CHANNEL::$PACKAGE_NAME=$PACKAGE_VERSION python=$PYTHON_VERSION $C_COMPILER $FORTRAN_COMPILER
           mamba activate test_py$PYTHON_VERSION
 
           ./configure --prefix=$CONDA_PREFIX --with-python --with-uuid=$CONDA_PREFIX --with-json-c=$CONDA_PREFIX --with-udunits2=$CONDA_PREFIX --with-netcdf=$CONDA_PREFIX  --enable-verbose-test


### PR DESCRIPTION
Resolves #881 

Use the syntax `<channel_name>::<package_name>` with the command `mamba create` when installing CMOR from the local channel, i.e. the directory where conda-build saved the CMOR builds.