### PR TITLE
Keep package version updated in nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.runner.RUNNER_OS }}
     env:
       PACKAGE_NAME: cmor
-      PACKAGE_VERSION: 3.14.0
+      PACKAGE_VERSION: 3.14.3
       PYTHON_VERSION: ${{ matrix.python_version }}
       CONDA_FORGE_CHANNEL: conda-forge
       CONDA_USER: pcmdi

--- a/tools/update_cmor_release.sh
+++ b/tools/update_cmor_release.sh
@@ -7,7 +7,8 @@ Usage:
   tools/update_cmor_release.sh --minor N --patch N
   tools/update_cmor_release.sh --version X.Y.Z
 
-Updates CMOR minor/patch version numbers and sets the release date to today.
+Updates CMOR minor/patch version numbers, refreshes the release date,
+and syncs the nightly build workflow package version.
 Also regenerates ./configure by running autoconf after updating configure.ac.
 
 Options:
@@ -73,12 +74,14 @@ configure_sh="${repo_root}/configure"
 cmor_h="${repo_root}/include/cmor.h"
 setup_py_in="${repo_root}/setup.py.in"
 citation="${repo_root}/CITATION.cff"
+nightly_workflow="${repo_root}/.github/workflows/nightly-build.yml"
 
 [[ -f "${configure_ac}" ]] || die "missing file: ${configure_ac}"
 [[ -f "${configure_sh}" ]] || die "missing file: ${configure_sh}"
 [[ -f "${cmor_h}" ]] || die "missing file: ${cmor_h}"
 [[ -f "${setup_py_in}" ]] || die "missing file: ${setup_py_in}"
 [[ -f "${citation}" ]] || die "missing file: ${citation}"
+[[ -f "${nightly_workflow}" ]] || die "missing file: ${nightly_workflow}"
 
 current_version="$(perl -ne 'if (/^AC_INIT\(\[cmor\],\[(\d+)\.(\d+)\.(\d+)\]/) { print "$1.$2.$3\n"; exit }' "${configure_ac}")"
 [[ -n "${current_version}" ]] || die "could not parse current version from ${configure_ac}"
@@ -126,6 +129,7 @@ cleanup() {
     cp -p "${backup_dir}/cmor.h" "${cmor_h}" 2>/dev/null || true
     cp -p "${backup_dir}/setup.py.in" "${setup_py_in}" 2>/dev/null || true
     cp -p "${backup_dir}/CITATION.cff" "${citation}" 2>/dev/null || true
+    cp -p "${backup_dir}/nightly-build.yml" "${nightly_workflow}" 2>/dev/null || true
   fi
   rm -rf "${backup_dir}" 2>/dev/null || true
 }
@@ -136,6 +140,7 @@ cp -p "${configure_sh}" "${backup_dir}/configure"
 cp -p "${cmor_h}" "${backup_dir}/cmor.h"
 cp -p "${setup_py_in}" "${backup_dir}/setup.py.in"
 cp -p "${citation}" "${backup_dir}/CITATION.cff"
+cp -p "${nightly_workflow}" "${backup_dir}/nightly-build.yml"
 
 export CMOR_NEW_VERSION="${new_version}"
 export CMOR_NEW_MINOR="${minor}"
@@ -166,9 +171,13 @@ perl_inplace_or_die "${citation}" \
   'BEGIN{$c=0} $c += s/^(date-released:\s*)[0-9]{4}-[0-9]{2}-[0-9]{2}\s*$/$1 . $ENV{CMOR_NEW_DATE}/mse; END{exit($c?0:2)}' \
   "set CITATION.cff date-released"
 
+perl_inplace_or_die "${nightly_workflow}" \
+  'BEGIN{$c=0} $c += s/^(\s*PACKAGE_VERSION:\s*)[0-9]+\.[0-9]+\.[0-9]+\s*$/$1 . $ENV{CMOR_NEW_VERSION}/mse; END{exit($c?0:2)}' \
+  "set nightly-build.yml PACKAGE_VERSION"
+
 (
   cd -- "${repo_root}"
-  autoconf || die "autoconf failed; revert changes with: git checkout -- configure.ac configure include/cmor.h setup.py.in CITATION.cff"
+  autoconf || die "autoconf failed; revert changes with: git checkout -- configure.ac configure include/cmor.h setup.py.in CITATION.cff .github/workflows/nightly-build.yml"
 
 )
 
@@ -178,3 +187,4 @@ echo "  ${configure_sh}"
 echo "  ${cmor_h}"
 echo "  ${setup_py_in}"
 echo "  ${citation}"
+echo "  ${nightly_workflow}"


### PR DESCRIPTION
The nightly builds were still using package version 3.14.0.

This updates the script used to bump version numbers to include the nightly build config.