### PR TITLE
Remove redundant "CF standards" from history template.

### DIFF
--- a/Test/test_cmor_CMIP7.py
+++ b/Test/test_cmor_CMIP7.py
@@ -242,7 +242,8 @@ class TestCMIP7(unittest.TestCase):
         ds.close()
 
     def test_conventions_set_by_user(self):
-        self._load_dataset(updated_fields={"Conventions": "CF-1.13"})
+        conventions = "CF-1.13"
+        self._load_dataset(updated_fields={"Conventions": conventions})
 
         data = numpy.array([27, 28])
         time = numpy.array([15, 45])
@@ -258,7 +259,9 @@ class TestCMIP7(unittest.TestCase):
         self.assertEqual(cmor.close(), 0)
 
         ds = Dataset(filename)
-        self.assertEqual("CF-1.13", ds.getncattr("Conventions"))
+        self.assertEqual(conventions, ds.getncattr("Conventions"))
+        self.assertIn(f"CMOR rewrote data to be consistent with {conventions} "
+                      "and CMIP7 data requirements.", ds.getncattr("history"))
 
         ds.close()
 

--- a/include/cmor.h
+++ b/include/cmor.h
@@ -320,7 +320,7 @@
 #define CMOR_DEFAULT_PATH_TEMPLATE    "<mip_era><activity_id><institution_id><source_id><experiment_id><member_id><table><variable_id><grid_label><version>"
 #define CMOR_DEFAULT_FILE_TEMPLATE    "<variable_id><table><source_id><experiment_id><member_id><grid_label>"
 #define CMOR_DEFAULT_FURTHERURL_TEMPLATE "https://furtherinfo.es-doc.org/<mip_era><institution_id><source_id><experiment_id><sub_experiment_id><variant_label>"
-#define CMOR_DEFAULT_HISTORY_TEMPLATE "%s ; CMOR rewrote data to be consistent with <mip_era>, <Conventions> and CF standards."
+#define CMOR_DEFAULT_HISTORY_TEMPLATE "%s ; CMOR rewrote data to be consistent with <Conventions> and <mip_era> data requirements."
 //#define EXTERNAL_VARIABLE_REGEX       "([[:alpha:]]+):[[:blank:]]*([[:alpha:]]+)[[:blank:]]*([[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 #define EXTERNAL_VARIABLE_REGEX       "[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+)([[:blank:]]*[[:alpha:]]+:[[:blank:]]*([[:alpha:]]+))*"
 


### PR DESCRIPTION
Resolves #966 
