### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,7 +35,7 @@ jobs:
             C_COMPILER: clang_osx-64 
             FORTRAN_COMPILER: gfortran_osx-64
             PROJECT_DIR: workdir/macos_64
-        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python_version: ['3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.runner.RUNNER_OS }}
     env:
       PACKAGE_NAME: cmor

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.runner.RUNNER_OS }}
     env:
       CIBW_ARCHS: ${{ matrix.runner.CIBW_ARCHS }}
-      CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
       CIBW_SKIP: "*-musllinux*"
       CIBW_BEFORE_ALL: "bash {project}/ci-support/cibw-before-all.sh"
       CIBW_BEFORE_BUILD: "bash {project}/ci-support/cibw-before-build.sh"


### PR DESCRIPTION
Due to Python 3.10 being dropped from cmor-feedstock (https://github.com/conda-forge/cmor-feedstock/pull/100), we will drop support for it here.