### PR TITLE
Allow user-defined values for `source`, `experiment`, and `institution`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -237,6 +237,7 @@ test_python: python
 	env TEST_NAME=Test/test_cmor_unsupported_calendar.py make test_a_python
 	env TEST_NAME=Test/test_cmor_time_interval_check.py make test_a_python
 	env TEST_NAME=Test/test_cmor_license_attributes.py make test_a_python
+	env TEST_NAME=Test/test_cmor_optional_derived_attributes.py make test_a_python
 	env TEST_NAME=Test/test_cmor_nested_cv_attribute.py make test_a_python
 	env TEST_NAME=Test/test_cmor_path_and_file_templates.py make test_a_python
 	env TEST_NAME=Test/test_cmor_check_cv_structure.py make test_a_python

--- a/Src/cmor_CV.c
+++ b/Src/cmor_CV.c
@@ -282,6 +282,26 @@ cmor_CV_def_t *cmor_CV_rootsearch(cmor_CV_def_t * CV, char *key)
     return (NULL);
 }
 
+/* Return whether an attribute is listed as required by the CV. */
+static int cmor_CV_is_required_global_attribute(cmor_CV_def_t *CV,
+                                                 const char *attribute)
+{
+    cmor_CV_def_t *required_attrs;
+    int i;
+
+    required_attrs = cmor_CV_rootsearch(CV, CV_KEY_REQUIRED_GBL_ATTRS);
+    if (required_attrs == NULL) {
+        return (0);
+    }
+
+    for (i = 0; i < required_attrs->anElements; i++) {
+        if (strcmp(attribute, required_attrs->aszValue[i]) == 0) {
+            return (1);
+        }
+    }
+    return (0);
+}
+
 /************************************************************************/
 /*                      cmor_CV_get_value()                             */
 /************************************************************************/
@@ -626,6 +646,8 @@ int cmor_CV_checkSourceID(cmor_CV_def_t * CV)
     char CV_Filename[CMOR_MAX_STRING];
     char CMOR_Filename[CMOR_MAX_STRING];
     int rc;
+    int source_is_required;
+    int user_defined_source;
     int i;
     int j = 0;
 
@@ -652,6 +674,10 @@ int cmor_CV_checkSourceID(cmor_CV_def_t * CV)
         cmor_pop_traceback();
         return (-1);
     }
+    source_is_required = cmor_CV_is_required_global_attribute(
+        CV, GLOBAL_ATT_SOURCE);
+    user_defined_source = (cmor_has_cur_dataset_attribute(
+        GLOBAL_ATT_SOURCE) == 0);
     // retrieve source_id
     rc = cmor_get_cur_dataset_attribute(GLOBAL_ATT_SOURCE_ID, szSource_ID);
     if (rc != 0) {
@@ -701,7 +727,8 @@ int cmor_CV_checkSourceID(cmor_CV_def_t * CV)
                 nLen = pos - CV_source_id->oValue[j].szValue + 1;
             }
             szSubstring[nLen] = '\0';
-            if (strncmp(szSubstring, szSource, nLen) != 0) {
+            if (source_is_required &&
+                strncmp(szSubstring, szSource, nLen) != 0) {
                 cmor_handle_error_variadic(
                          "Your input attribute \"%s\" with value \n! \"%s\" "
                          "will be replaced with "
@@ -735,8 +762,10 @@ int cmor_CV_checkSourceID(cmor_CV_def_t * CV)
     // Set/replace attribute.
     cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_SOURCE_ID,
                                             CV_source_id->key, 1);
-    cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_SOURCE,
-                                            CV_source_id->oValue[j].szValue, 1);
+    if (source_is_required || !user_defined_source) {
+        cmor_set_cur_dataset_attribute_internal(
+            GLOBAL_ATT_SOURCE, CV_source_id->oValue[j].szValue, 1);
+    }
 
     cmor_pop_traceback();
     return (0);
@@ -1492,6 +1521,14 @@ int cmor_CV_checkExperiment(cmor_CV_def_t * CV)
                 ierr = -1;
             continue;
         }
+        /* The experiment_id supplies a default experiment label.  A CV may
+         * leave that label optional, in which case an explicit user value
+         * takes precedence over the registered default. */
+        if (strcmp(CV_experiment_attr->key, GLOBAL_ATT_EXPERIMENT) == 0 &&
+            !cmor_CV_is_required_global_attribute(
+                CV, GLOBAL_ATT_EXPERIMENT) && rc == 0) {
+            continue;
+        }
         // Warn user if experiment value from input file is different than
         // Controlled Vocabulary value.
         // experiment from Controlled Vocabulary will replace User entry value.
@@ -1577,6 +1614,7 @@ int cmor_CV_setInstitution(cmor_CV_def_t * CV)
     char CMOR_Filename[CMOR_MAX_STRING];
     char CV_Filename[CMOR_MAX_STRING];
     int rc;
+    int institution_is_required;
 
     cmor_add_traceback("_CV_setInstitution");
 /* -------------------------------------------------------------------- */
@@ -1624,6 +1662,8 @@ int cmor_CV_setInstitution(cmor_CV_def_t * CV)
         cmor_pop_traceback();
         return (-1);
     }
+    institution_is_required = cmor_CV_is_required_global_attribute(
+        CV, GLOBAL_ATT_INSTITUTION);
 /* -------------------------------------------------------------------- */
 /* Did the user defined an Institution Attribute?                       */
 /* -------------------------------------------------------------------- */
@@ -1653,8 +1693,9 @@ int cmor_CV_setInstitution(cmor_CV_def_t * CV)
 /* -------------------------------------------------------------------- */
 /*  Check if they have the same string                                  */
 /* -------------------------------------------------------------------- */
-        if (strncmp(szInstitution, CV_institution->szValue, CMOR_MAX_STRING) !=
-            0) {
+        if (institution_is_required &&
+            strncmp(szInstitution, CV_institution->szValue,
+                    CMOR_MAX_STRING) != 0) {
             cmor_handle_error_variadic(
                      "Your input attribute institution \"%s\" will be replaced with \n! "
                      "\"%s\" as defined in your Controlled Vocabulary file.\n! ",
@@ -1664,8 +1705,10 @@ int cmor_CV_setInstitution(cmor_CV_def_t * CV)
 /* -------------------------------------------------------------------- */
 /*   Set institution according to the Controlled Vocabulary                */
 /* -------------------------------------------------------------------- */
-    cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_INSTITUTION,
-                                            CV_institution->szValue, 1);
+    if (institution_is_required || rc != 0) {
+        cmor_set_cur_dataset_attribute_internal(GLOBAL_ATT_INSTITUTION,
+                                                CV_institution->szValue, 1);
+    }
     cmor_pop_traceback();
     return (0);
 }

--- a/Test/test_cmor_optional_derived_attributes.py
+++ b/Test/test_cmor_optional_derived_attributes.py
@@ -102,32 +102,45 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
             for attribute, value in expected.items():
                 self.assertEqual(dataset.getncattr(attribute), value)
 
-    def test_user_values_do_not_override_required_cv_values(self):
+    def test_user_values_do_not_override_required_source_and_institution(self):
         required = self.cv["CV"]["required_global_attributes"]
-        required.extend(DERIVED_ATTRIBUTES)
+        required.extend(("source", "institution"))
         with self.cv_path.open("w") as cv_file:
             json.dump(self.cv, cv_file)
 
         user_values = {
             "source": "User supplied source description",
-            "experiment": "User supplied experiment description",
             "institution": "User supplied institution description",
         }
-        with self.assertRaises(cmor.CMORError):
-            self._create_output(user_values)
+        filename = self._create_output(user_values)
 
         cv = self.cv["CV"]
         expected = {
             "source": cv["source_id"][self.user_input["source_id"]]["source"],
-            "experiment": cv["experiment_id"][
-                self.user_input["experiment_id"]
-            ]["experiment"],
             "institution": cv["institution_id"][
                 self.user_input["institution_id"]
             ],
         }
-        for attribute, value in expected.items():
-            self.assertEqual(cmor.get_cur_dataset_attribute(attribute), value)
+
+        with Dataset(filename) as dataset:
+            for attribute, value in expected.items():
+                self.assertEqual(dataset.getncattr(attribute), value)
+
+    def test_user_value_does_not_override_required_experiment(self):
+        required = self.cv["CV"]["required_global_attributes"]
+        required.append("experiment")
+        with self.cv_path.open("w") as cv_file:
+            json.dump(self.cv, cv_file)
+
+        with self.assertRaises(cmor.CMORError):
+            self._create_output(
+                {"experiment": "User supplied experiment description"}
+            )
+
+        expected = self.cv["CV"]["experiment_id"][
+            self.user_input["experiment_id"]
+        ]["experiment"]
+        self.assertEqual(cmor.get_cur_dataset_attribute("experiment"), expected)
 
 
 if __name__ == "__main__":

--- a/Test/test_cmor_optional_derived_attributes.py
+++ b/Test/test_cmor_optional_derived_attributes.py
@@ -102,6 +102,33 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
             for attribute, value in expected.items():
                 self.assertEqual(dataset.getncattr(attribute), value)
 
+    def test_user_values_do_not_override_required_cv_values(self):
+        required = self.cv["CV"]["required_global_attributes"]
+        required.extend(DERIVED_ATTRIBUTES)
+        with self.cv_path.open("w") as cv_file:
+            json.dump(self.cv, cv_file)
+
+        user_values = {
+            "source": "User supplied source description",
+            "experiment": "User supplied experiment description",
+            "institution": "User supplied institution description",
+        }
+        with self.assertRaises(cmor.CMORError):
+            self._create_output(user_values)
+
+        cv = self.cv["CV"]
+        expected = {
+            "source": cv["source_id"][self.user_input["source_id"]]["source"],
+            "experiment": cv["experiment_id"][
+                self.user_input["experiment_id"]
+            ]["experiment"],
+            "institution": cv["institution_id"][
+                self.user_input["institution_id"]
+            ],
+        }
+        for attribute, value in expected.items():
+            self.assertEqual(cmor.get_cur_dataset_attribute(attribute), value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Test/test_cmor_optional_derived_attributes.py
+++ b/Test/test_cmor_optional_derived_attributes.py
@@ -20,6 +20,7 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
         self.tmpdir = Path(tempfile.mkdtemp(dir=str(Path("Test").resolve())))
         self.cv_path = self.tmpdir / "CMIP6_CV.json"
         self.input_path = self.tmpdir / "input.json"
+        self.log_path = self.tmpdir / "cmor.log"
         self.output_path = self.tmpdir / "output"
         self.output_path.mkdir()
 
@@ -58,6 +59,7 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
             inpath="Tables",
             netcdf_file_action=cmor.CMOR_REPLACE,
             create_subdirectories=1,
+            logfile=str(self.log_path),
         )
         self.assertEqual(cmor.dataset_json(str(self.input_path)), 0)
         cmor.load_table("CMIP6_Omon.json")
@@ -126,6 +128,16 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
             for attribute, value in expected.items():
                 self.assertEqual(dataset.getncattr(attribute), value)
 
+        log = self.log_path.read_text()
+        self.assertIn(
+            'Warning: Your input attribute "source" with value', log
+        )
+        self.assertIn(
+            'Warning: Your input attribute institution '
+            '"User supplied institution description" will be replaced with',
+            log,
+        )
+
     def test_user_value_does_not_override_required_experiment(self):
         required = self.cv["CV"]["required_global_attributes"]
         required.append("experiment")
@@ -137,10 +149,15 @@ class TestOptionalDerivedAttributes(unittest.TestCase):
                 {"experiment": "User supplied experiment description"}
             )
 
-        expected = self.cv["CV"]["experiment_id"][
-            self.user_input["experiment_id"]
-        ]["experiment"]
-        self.assertEqual(cmor.get_cur_dataset_attribute("experiment"), expected)
+        log = self.log_path.read_text()
+        self.assertIn(
+            'Error: Your input attribute "experiment" with value', log
+        )
+        self.assertIn(
+            'needs to be replaced with value '
+            '"preindustrial control with interactive ice sheet"',
+            log,
+        )
 
 
 if __name__ == "__main__":

--- a/Test/test_cmor_optional_derived_attributes.py
+++ b/Test/test_cmor_optional_derived_attributes.py
@@ -1,0 +1,107 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import cmor
+import numpy
+from netCDF4 import Dataset
+
+
+CV_PATH = Path("Tables/CMIP6_CV.json")
+INPUT_PATH = Path("Test/CMOR_input_example.json")
+DERIVED_ATTRIBUTES = ("source", "experiment", "institution")
+
+
+class TestOptionalDerivedAttributes(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(dir=str(Path("Test").resolve())))
+        self.cv_path = self.tmpdir / "CMIP6_CV.json"
+        self.input_path = self.tmpdir / "input.json"
+        self.output_path = self.tmpdir / "output"
+        self.output_path.mkdir()
+
+        with CV_PATH.open() as cv_file:
+            self.cv = json.load(cv_file)
+        required = self.cv["CV"]["required_global_attributes"]
+        self.cv["CV"]["required_global_attributes"] = [
+            name for name in required if name not in DERIVED_ATTRIBUTES
+        ]
+        with self.cv_path.open("w") as cv_file:
+            json.dump(self.cv, cv_file)
+
+        with INPUT_PATH.open() as input_file:
+            self.user_input = json.load(input_file)
+        self.user_input["_controlled_vocabulary_file"] = os.path.relpath(
+            self.cv_path, Path("Tables").resolve()
+        )
+        self.user_input["outpath"] = str(self.output_path)
+        self.user_input["frequency"] = "mon"
+
+    def tearDown(self):
+        cmor.close()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _create_output(self, values):
+        user_input = self.user_input.copy()
+        for attribute in DERIVED_ATTRIBUTES:
+            if attribute in values:
+                user_input[attribute] = values[attribute]
+            else:
+                user_input.pop(attribute, None)
+        with self.input_path.open("w") as input_file:
+            json.dump(user_input, input_file)
+
+        cmor.setup(
+            inpath="Tables",
+            netcdf_file_action=cmor.CMOR_REPLACE,
+            create_subdirectories=1,
+        )
+        self.assertEqual(cmor.dataset_json(str(self.input_path)), 0)
+        cmor.load_table("CMIP6_Omon.json")
+        time = cmor.axis(
+            table_entry="time",
+            units="days since 2010-01-01",
+            coord_vals=numpy.array([15.0, 45.0]),
+            cell_bounds=numpy.array([0.0, 30.0, 60.0]),
+        )
+        variable = cmor.variable("thetaoga", units="deg_C", axis_ids=[time])
+        self.assertEqual(cmor.write(variable, numpy.array([1.0, 2.0])), 0)
+        filename = cmor.close(variable, file_name=True)
+        self.assertEqual(cmor.close(), 0)
+        return filename
+
+    def test_user_values_override_optional_cv_defaults(self):
+        expected = {
+            "source": "User supplied source description",
+            "experiment": "User supplied experiment description",
+            "institution": "User supplied institution description",
+        }
+        filename = self._create_output(expected)
+
+        with Dataset(filename) as dataset:
+            for attribute, value in expected.items():
+                self.assertEqual(dataset.getncattr(attribute), value)
+
+    def test_ids_supply_defaults_when_optional_values_are_absent(self):
+        filename = self._create_output({})
+        cv = self.cv["CV"]
+        expected = {
+            "source": cv["source_id"][self.user_input["source_id"]]["source"],
+            "experiment": cv["experiment_id"][
+                self.user_input["experiment_id"]
+            ]["experiment"],
+            "institution": cv["institution_id"][
+                self.user_input["institution_id"]
+            ],
+        }
+
+        with Dataset(filename) as dataset:
+            for attribute, value in expected.items():
+                self.assertEqual(dataset.getncattr(attribute), value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci-support/test-wheel.sh
+++ b/ci-support/test-wheel.sh
@@ -202,6 +202,7 @@ wheel_python_tests=(
     "Test/test_cmor_unsupported_calendar.py"
     "Test/test_cmor_time_interval_check.py"
     "Test/test_cmor_license_attributes.py"
+    "Test/test_cmor_optional_derived_attributes.py"
     "Test/test_cmor_nested_cv_attribute.py"
     "Test/test_cmor_path_and_file_templates.py"
     "Test/test_cmor_parent_attrs.py"


### PR DESCRIPTION
Resolves #988 

Allow the user to set values for `source`, `experiment`, and `institution`.

This will overwrite the values that are set by default from the CV for `source_id`, `experiment_id`, and `institution_id`.

If `source`, `experiment`, and `institution` are in `required_global_attributes`, then the values from the CV will overwrite the user values.