### PR TITLE
Reverse the order of the projection coordinates of grids from [x, y] to [y, x]

### DIFF
--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -479,8 +479,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
     } else if (strcmp(name, "latitude_longitude") == 0) {
         *natt = 0;
         *ndims = 2;
-        strcpy(dims[0], "longitude");
-        strcpy(dims[1], "latitude");
+        strcpy(dims[0], "latitude");
+        strcpy(dims[1], "longitude");
     } else if (strcmp(name, "mercator") == 0) {
         *natt = 5;
         strcpy(att[0], "longitude_of_projection_origin");
@@ -528,8 +528,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[1], "grid_north_pole_longitude");
         strcpy(att[2], "north_pole_grid_longitude");
         *ndims = 2;
-        strcpy(dims[0], "grid_longitude");
-        strcpy(dims[1], "grid_latitude");
+        strcpy(dims[0], "grid_latitude");
+        strcpy(dims[1], "grid_longitude");
     } else if (strcmp(name, "sinusoidal") == 0) {
         *natt = 3;
         strcpy(att[0], "longitude_of_projection_origin");

--- a/Src/cmor_grids.c
+++ b/Src/cmor_grids.c
@@ -425,8 +425,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "azimuthal_equidistant") == 0) {
         *natt = 4;
         strcpy(att[0], "longitude_of_projection_origin");
@@ -434,8 +434,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "geostationary") == 0) {
         *natt = 7;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -446,8 +446,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[5], "false_easting");
         strcpy(att[6], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "lambert_azimuthal_equal_area") == 0) {
         *natt = 4;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -455,8 +455,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "lambert_conformal_conic") == 0) {
         *natt = 5;
         strcpy(att[0], "standard_parallel");
@@ -465,8 +465,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "lambert_cylindrical_equal_area") == 0) {
         *natt = 4;
         strcpy(att[0], "standard_parallel");
@@ -474,13 +474,13 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "latitude_longitude") == 0) {
         *natt = 0;
         *ndims = 2;
-        strcpy(dims[0], "latitude");
-        strcpy(dims[1], "longitude");
+        strcpy(dims[0], "longitude");
+        strcpy(dims[1], "latitude");
     } else if (strcmp(name, "mercator") == 0) {
         *natt = 5;
         strcpy(att[0], "longitude_of_projection_origin");
@@ -489,8 +489,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "oblique_mercator") == 0) {
         *natt = 6;
         strcpy(att[0], "azimuth_of_central_line");
@@ -500,8 +500,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[4], "false_easting");
         strcpy(att[5], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "orthographic") == 0) {
         *natt = 4;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -509,8 +509,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[2], "false_easting");
         strcpy(att[3], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "polar_stereographic") == 0) {
         *natt = 6;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -520,24 +520,24 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[4], "false_easting");
         strcpy(att[5], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "rotated_latitude_longitude") == 0) {
         *natt = 3;
         strcpy(att[0], "grid_north_pole_latitude");
         strcpy(att[1], "grid_north_pole_longitude");
         strcpy(att[2], "north_pole_grid_longitude");
         *ndims = 2;
-        strcpy(dims[0], "grid_latitude");
-        strcpy(dims[1], "grid_longitude");
+        strcpy(dims[0], "grid_longitude");
+        strcpy(dims[1], "grid_latitude");
     } else if (strcmp(name, "sinusoidal") == 0) {
         *natt = 3;
         strcpy(att[0], "longitude_of_projection_origin");
         strcpy(att[1], "false_easting");
         strcpy(att[2], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "stereographic") == 0) {
         *natt = 5;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -546,8 +546,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "transverse_mercator") == 0) {
         *natt = 5;
         strcpy(att[0], "scale_factor_at_central_meridian");
@@ -556,8 +556,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     } else if (strcmp(name, "vertical_perspective") == 0) {
         *natt = 5;
         strcpy(att[0], "latitude_of_projection_origin");
@@ -566,8 +566,8 @@ int cmor_grid_valid_mapping_attribute_names(char *name, int *natt, char (*att)
         strcpy(att[3], "false_easting");
         strcpy(att[4], "false_northing");
         *ndims = 2;
-        strcpy(dims[0], "projection_x_coordinate");
-        strcpy(dims[1], "projection_y_coordinate");
+        strcpy(dims[0], "projection_y_coordinate");
+        strcpy(dims[1], "projection_x_coordinate");
     }
 
     /* Now looks up in table */

--- a/Test/test_cmor_crs.py
+++ b/Test/test_cmor_crs.py
@@ -91,6 +91,15 @@ class TestCRS(BaseCVsTest):
     def test_crs_without_crs_wkt(self):
         ds = Dataset(self.make_crs_file())
 
+        self.assertEqual(ds.variables['baresoilFrac'].dimensions,
+                         ('time', 'y', 'x'))
+        self.assertEqual(ds.variables['latitude'].dimensions, ('y', 'x'))
+        self.assertEqual(ds.variables['longitude'].dimensions, ('y', 'x'))
+        self.assertEqual(ds.variables['vertices_latitude'].dimensions,
+                         ('y', 'x', 'vertices'))
+        self.assertEqual(ds.variables['vertices_longitude'].dimensions,
+                         ('y', 'x', 'vertices'))
+
         self.assertTrue('crs' in ds.variables)
         attrs = ds.variables['crs'].ncattrs()
         test_attrs = {

--- a/Test/test_cmor_crs.py
+++ b/Test/test_cmor_crs.py
@@ -212,8 +212,8 @@ class TestLatLonGridMapping(BaseCVsTest):
         lat_bounds[:, 1] = lat_coords + 0.5
 
         lat_grid, lon_grid = np.broadcast_arrays(
-            np.expand_dims(lat_coords, 0),
-            np.expand_dims(lon_coords, 1)
+            np.expand_dims(lat_coords, 1),
+            np.expand_dims(lon_coords, 0)
             )
 
         axes = [
@@ -262,6 +262,14 @@ class TestLatLonGridMapping(BaseCVsTest):
 
         filename = cmor.close(ivar, file_name=True)
         ds = Dataset(filename)
+
+        self.assertEqual(ds.variables['baresoilFrac'].dimensions,
+                         ('time', 'lat', 'lon'))
+        self.assertEqual(ds.variables['latitude'].dimensions, ('lat', 'lon'))
+        self.assertEqual(ds.variables['longitude'].dimensions, ('lat', 'lon'))
+        self.assertEqual(ds.variables['type'].dimensions, ('strlen',))
+        np.testing.assert_array_equal(ds.variables['latitude'][:], lat_grid)
+        np.testing.assert_array_equal(ds.variables['longitude'][:], lon_grid)
 
         self.assertTrue('crs' in ds.variables)
         attrs = ds.variables['crs'].ncattrs()


### PR DESCRIPTION
Resolves #996 

Example from the file generated by [examples/python/example_06_complex_grid.py](https://github.com/PCMDI/cmor/blob/main/examples/python/example_06_complex_grid.py).

```
        double latitude(y, x) ;
                latitude:standard_name = "latitude" ;
                latitude:long_name = "latitude" ;
                latitude:units = "degrees_north" ;
                latitude:missing_value = 1.e+20 ;
                latitude:_FillValue = 1.e+20 ;
                latitude:bounds = "vertices_latitude" ;
        double longitude(y, x) ;
                longitude:standard_name = "longitude" ;
                longitude:long_name = "longitude" ;
                longitude:units = "degrees_east" ;
                longitude:missing_value = 1.e+20 ;
                longitude:_FillValue = 1.e+20 ;
                longitude:bounds = "vertices_longitude" ;
        double vertices_latitude(y, x, vertices) ;
                vertices_latitude:units = "degrees_north" ;
                vertices_latitude:missing_value = 1.e+20 ;
                vertices_latitude:_FillValue = 1.e+20 ;
        double vertices_longitude(y, x, vertices) ;
                vertices_longitude:units = "degrees_east" ;
                vertices_longitude:missing_value = 1.e+20 ;
                vertices_longitude:_FillValue = 1.e+20 ;
        float hfls(time, y, x) ;
                hfls:standard_name = "surface_upward_latent_heat_flux" ;
                hfls:long_name = "Surface Upward Latent Heat Flux" ;
                hfls:units = "W m-2" ;
                hfls:cell_methods = "area: time: mean" ;
                hfls:missing_value = 1.e+20f ;
                hfls:_FillValue = 1.e+20f ;
                hfls:cell_measures = "area: areacella" ;
                hfls:grid_mapping = "lambert_conformal_conic" ;
                hfls:coordinates = "latitude longitude" ;
```